### PR TITLE
Prevent overwriting preexisting rdas

### DIFF
--- a/R/exp_all_figs_tables.R
+++ b/R/exp_all_figs_tables.R
@@ -93,15 +93,16 @@ exp_all_figs_tables <- function(
         relative,
         make_rda,
         rda_dir
-      ) |>
-        suppressWarnings() |>
-        invisible()
-
-      message("Exported plot_recruitment")
+      ) #|>
+       # suppressWarnings() |>
+       # invisible()
     },
     error = function(e) {
-      message("Failed to export plot_recruitment. Tip: check that your arguments are correct.")
+      message("plot_recruitment failed to run. Tip: check that your arguments are correct.")
       print(e)
+    },
+    warning = function(w) {
+      message("plot_recruitment did not run and the existing file was not overwritten.")
     }
   )
 
@@ -118,46 +119,54 @@ exp_all_figs_tables <- function(
         relative,
         make_rda,
         rda_dir
-      ) |>
-        suppressWarnings() |>
-        invisible()
+      ) #|>
+        # suppressWarnings() |>
+        # invisible()
 
-      message("Exported plot_biomass")
     },
     error = function(e) {
-      message("Failed to export plot_biomass Tip: check that your arguments are correct.")
+      message("plot_biomass failed to run. Tip: check that your arguments are correct.")
       print(e)
+    },
+    warning = function(w) {
+      message("plot_biomass did not run and the existing file was not overwritten.")
     }
   )
 
 
   tryCatch(
     {
-      stockplotr::plot_landings(dat, unit_label = landings_unit_label, make_rda, rda_dir) |>
-        suppressWarnings() |>
-        invisible()
+      stockplotr::plot_landings(dat,
+                                unit_label = landings_unit_label,
+                                make_rda, rda_dir) # |>
+       # suppressWarnings() |>
+       # invisible()
 
-      message("Exported plot_landings")
     },
     error = function(e) {
-      message("Failed to export plot_landings. Tip: check that your arguments are correct.")
+      message("plot_landings failed to run. Tip: check that your arguments are correct.")
       print(e)
+    },
+    warning = function(w) {
+      message("plot_landings did not run and the existing file was not overwritten.")
     }
   )
 
   tryCatch(
     {
-      stockplotr::plot_recruitment_deviations(dat, end_year, n_projected_years, make_rda, rda_dir) |>
-        suppressWarnings() |>
-        invisible()
+      stockplotr::plot_recruitment_deviations(dat, end_year, n_projected_years, make_rda, rda_dir) #|>
+       # suppressWarnings() |>
+       # invisible()
 
-      message("Exported plot_recruitment_deviations")
     },
     error = function(e) {
       message(
-        "Failed to export plot_recruitment_deviations. Tip: check that your arguments are correct."
+        "plot_recruitment_deviations failed to run. Tip: check that your arguments are correct."
       )
       print(e)
+    },
+    warning = function(w) {
+      message("plot_recruitment_deviations did not run and the existing file was not overwritten.")
     }
   )
 
@@ -166,9 +175,7 @@ exp_all_figs_tables <- function(
   #                        recruitment_label = recruitment_unit_label,
   #                        end_year,
   #                        make_rda,
-  #                        rda_dir) |> suppressWarnings() |> invisible()
-  #
-  # message("Exported plot_spawn_recruitment")
+  #                        rda_dir)# |> suppressWarnings() |> invisible()
 
   tryCatch(
     {
@@ -183,15 +190,16 @@ exp_all_figs_tables <- function(
         n_projected_years,
         make_rda,
         rda_dir
-      ) |>
-        suppressWarnings() |>
-        invisible()
-
-      message("Exported plot_spawning_biomass")
+      )# |>
+       # suppressWarnings() |>
+       # invisible()
     },
     error = function(e) {
-      message("Failed to export plot_spawning_biomass. Tip: check that your arguments are correct.")
+      message("plot_spawning_biomass failed to run. Tip: check that your arguments are correct.")
       print(e)
+    },
+    warning = function(w) {
+      message("plot_spawning_biomass did not run and the existing file was not overwritten.")
     }
   )
 
@@ -199,9 +207,7 @@ exp_all_figs_tables <- function(
   # stockplotr::plot_indices(dat,
   #                    unit_label = indices_unit_label,
   #                    make_rda,
-  #                    rda_dir) |> suppressWarnings() |> invisible()
-  #
-  # message("Exported plot_indices")
+  #                    rda_dir)# |> suppressWarnings() |> invisible()
 
   # tables
   tryCatch(
@@ -213,39 +219,39 @@ exp_all_figs_tables <- function(
         catch_unit_label,
         make_rda,
         rda_dir
-      ) |>
-        suppressWarnings() |>
-        invisible()
-
-      message("Exported table_bnc")
+      )# |>
+       # suppressWarnings() |>
+       # invisible()
     },
     error = function(e) {
-      message("Failed to export table_bnc. Tip: check that your arguments are correct.")
+      message("table_bnc failed to run. Tip: check that your arguments are correct.")
       print(e)
+    },
+    warning = function(w) {
+      message("table_bnc did not run and the existing file was not overwritten.")
     }
   )
 
   tryCatch(
     {
-      stockplotr::table_indices(dat, make_rda, rda_dir) |>
-        suppressWarnings() |>
-        invisible()
-
-      message("Exported table_indices")
+      stockplotr::table_indices(dat, make_rda, rda_dir)# |>
+       # suppressWarnings() |>
+       # invisible()
     },
     error = function(e) {
-      message("Failed to export table_indices. Tip: check that your arguments are correct.")
+      message("table_indices failed to run. Tip: check that your arguments are correct.")
       print(e)
+    },
+    warning = function(w) {
+      message("table_indices did not run and the existing file was not overwritten.")
     }
   )
 
   # uncomment when finished
-  # stockplotr::table_landings(dat) |> suppressWarnings() |> invisible()
-  #
-  # message("Exported table_landings")
+  # stockplotr::table_landings(dat)# |> suppressWarnings() |> invisible()
   #
   # undeveloped tables - add arguments after more development
-  # table_afsc_tier() |> suppressWarnings() |> invisible()
-  # table_harvest_projection() |> suppressWarnings() |> invisible()
+  # table_afsc_tier() #|> suppressWarnings() |> invisible()
+  # table_harvest_projection() #|> suppressWarnings() |> invisible()
   message("Finished export of figures and tables.")
 }

--- a/R/exp_all_figs_tables.R
+++ b/R/exp_all_figs_tables.R
@@ -85,24 +85,21 @@ exp_all_figs_tables <- function(
   tryCatch(
     {
       stockplotr::plot_recruitment(
-        dat,
+        dat = dat,
         unit_label = recruitment_unit_label,
         scale_amount = recruitment_scale_amount,
-        end_year,
-        n_projected_years,
-        relative,
-        make_rda,
-        rda_dir
+        end_year = end_year,
+        n_projected_years = n_projected_years,
+        relative = relative,
+        make_rda = TRUE,
+        rda_dir = rda_dir
       ) #|>
        # suppressWarnings() |>
        # invisible()
-    },
+       },
     error = function(e) {
       message("plot_recruitment failed to run. Tip: check that your arguments are correct.")
       print(e)
-    },
-    warning = function(w) {
-      message("plot_recruitment did not run and the existing file was not overwritten.")
     }
   )
 
@@ -127,9 +124,6 @@ exp_all_figs_tables <- function(
     error = function(e) {
       message("plot_biomass failed to run. Tip: check that your arguments are correct.")
       print(e)
-    },
-    warning = function(w) {
-      message("plot_biomass did not run and the existing file was not overwritten.")
     }
   )
 
@@ -138,7 +132,8 @@ exp_all_figs_tables <- function(
     {
       stockplotr::plot_landings(dat,
                                 unit_label = landings_unit_label,
-                                make_rda, rda_dir) # |>
+                                make_rda,
+                                rda_dir) # |>
        # suppressWarnings() |>
        # invisible()
 
@@ -146,15 +141,16 @@ exp_all_figs_tables <- function(
     error = function(e) {
       message("plot_landings failed to run. Tip: check that your arguments are correct.")
       print(e)
-    },
-    warning = function(w) {
-      message("plot_landings did not run and the existing file was not overwritten.")
     }
   )
 
   tryCatch(
     {
-      stockplotr::plot_recruitment_deviations(dat, end_year, n_projected_years, make_rda, rda_dir) #|>
+      stockplotr::plot_recruitment_deviations(dat,
+                                              end_year,
+                                              n_projected_years,
+                                              make_rda,
+                                              rda_dir) #|>
        # suppressWarnings() |>
        # invisible()
 
@@ -164,9 +160,6 @@ exp_all_figs_tables <- function(
         "plot_recruitment_deviations failed to run. Tip: check that your arguments are correct."
       )
       print(e)
-    },
-    warning = function(w) {
-      message("plot_recruitment_deviations did not run and the existing file was not overwritten.")
     }
   )
 
@@ -197,9 +190,6 @@ exp_all_figs_tables <- function(
     error = function(e) {
       message("plot_spawning_biomass failed to run. Tip: check that your arguments are correct.")
       print(e)
-    },
-    warning = function(w) {
-      message("plot_spawning_biomass did not run and the existing file was not overwritten.")
     }
   )
 
@@ -226,9 +216,6 @@ exp_all_figs_tables <- function(
     error = function(e) {
       message("table_bnc failed to run. Tip: check that your arguments are correct.")
       print(e)
-    },
-    warning = function(w) {
-      message("table_bnc did not run and the existing file was not overwritten.")
     }
   )
 
@@ -241,9 +228,6 @@ exp_all_figs_tables <- function(
     error = function(e) {
       message("table_indices failed to run. Tip: check that your arguments are correct.")
       print(e)
-    },
-    warning = function(w) {
-      message("table_indices did not run and the existing file was not overwritten.")
     }
   )
 

--- a/R/export_rda.R
+++ b/R/export_rda.R
@@ -59,18 +59,18 @@ export_rda <- function(final = NULL,
       "cap" = caps_alttext[[1]]
     )
   }
+  output_file_name <- paste0(topic_label, "_", fig_or_table, ".rda")
 
   # check if an rda_files folder already exists; if not, make one
   if (!dir.exists(fs::path(rda_dir, "rda_files"))) {
     dir.create(fs::path(rda_dir, "rda_files"))
   }
 
-  output_file_name <- paste0(topic_label, "_", fig_or_table, ".rda")
-
   # check if rda is already present. If so, check it should be overwritten
   if (file.exists(fs::path(rda_dir,
                            "rda_files",
                            output_file_name))) {
+
     question1 <- readline(
       paste0(
       "The ",
@@ -98,5 +98,24 @@ export_rda <- function(final = NULL,
       warning(
         paste0(output_file_name, " was not regenerated."))
     }
+  } else {
+
+    message(paste0(output_file_name, " will be newly created."))
+
+    # export rda
+    save(rda,
+         file = fs::path(
+           rda_dir,
+           "rda_files",
+           output_file_name
+         )
+    )
+
+    message(
+      paste0(
+        output_file_name,
+        " was exported."
+      )
+    )
   }
 }

--- a/R/export_rda.R
+++ b/R/export_rda.R
@@ -65,12 +65,38 @@ export_rda <- function(final = NULL,
     dir.create(fs::path(rda_dir, "rda_files"))
   }
 
-  # export rda
-  save(rda,
-    file = fs::path(
-      rda_dir,
-      "rda_files",
-      paste0(topic_label, "_", fig_or_table, ".rda")
-    )
-  )
+  output_file_name <- paste0(topic_label, "_", fig_or_table, ".rda")
+
+  # check if rda is already present. If so, check it should be overwritten
+  if (file.exists(fs::path(rda_dir,
+                           "rda_files",
+                           output_file_name))) {
+    question1 <- readline(
+      paste0(
+      "The ",
+      output_file_name,
+      " already exists within ",
+      fs::path(rda_dir, "rda_files"),
+      ". Would you like to overwrite this file? (Y/N)"))
+
+    if (regexpr(question1, "y", ignore.case = TRUE) == 1) {
+      # export rda
+      save(rda,
+        file = fs::path(
+          rda_dir,
+          "rda_files",
+          output_file_name
+        )
+      )
+      message(
+        paste0(
+          output_file_name,
+          " was regenerated and overwrote the previous version."
+        )
+      )
+    } else {
+      warning(
+        paste0(output_file_name, " was not regenerated."))
+    }
+  }
 }

--- a/tests/testthat/test-exp_all_figs_tables.R
+++ b/tests/testthat/test-exp_all_figs_tables.R
@@ -4,9 +4,14 @@ test_that("exp_all_figs_tables works when all figures/tables are plotted", {
     system.file("resources", "sample_data", "petrale_sole-after_2020.csv", package = "stockplotr")
   )
 
-  stockplotr::exp_all_figs_tables(dat,
+  stockplotr::exp_all_figs_tables(
+    dat,
     end_year = 2022,
+    n_projected_years = 3,
+    recruitment_unit_label = "mt",
+    recruitment_scale_amount = 1,
     ref_line = "unfished",
+    ref_point = 1000,
     ref_line_sb = "target",
     indices_unit_label = "CPUE",
     rda_dir = getwd()

--- a/tests/testthat/test-plot_biomass.R
+++ b/tests/testthat/test-plot_biomass.R
@@ -95,7 +95,7 @@ test_that("rda file made when indicated", {
   )
 
   # export rda
-  plot_biomass(
+  stockplotr::plot_biomass(
     dat,
     rda_dir = getwd(),
     make_rda = TRUE,


### PR DESCRIPTION
* Added checks to individual functions (with export_rda) and exp_all_figs_tables to prevent overwriting existing rda files
* Removed redundant "success" messages from exp_all_figs_tables
* Updated messages and warnings for clarity