### PR TITLE
Update key quantities calculations

### DIFF
--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -209,6 +209,7 @@ plot_spawning_biomass <- function(
       end_year = end_year,
       units = unit_label,
       ref_pt = ref_point,
+      ref_line = ref_line,
       scaling = scale_amount
     )
 

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -24,7 +24,7 @@
 #'
 plot_spawning_biomass <- function(
     dat,
-    unit_label = "metric ton",
+    unit_label = "metric tons",
     scale_amount = 1,
     ref_line = c("target", "unfished", "msy"),
     ref_point = NULL,

--- a/R/utils.R
+++ b/R/utils.R
@@ -262,6 +262,9 @@ add_more_key_quants <- function(
           "rel.ssb.max",
           as.character(rel.ssb.max)
         ))
+
+      message(paste0("rel.ssb.min: ", as.character(rel.ssb.min)))
+      message(paste0("rel.ssb.max: ", as.character(rel.ssb.max)))
       }
 
       # replace sr.ssb.min, sr.ssb.max, ssbtarg, ssb.min, and ssb.max placeholders
@@ -291,6 +294,8 @@ add_more_key_quants <- function(
 
       message(paste0("sr.ssb.min: ", as.character(sr.ssb.min)))
       message(paste0("sr.ssb.max: ", as.character(sr.ssb.max)))
+      message(paste0("ssb.min: ", as.character(ssb.min)))
+      message(paste0("ssb.max: ", as.character(ssb.max)))
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -240,6 +240,7 @@ add_more_key_quants <- function(
         as.numeric() |>
         round(digits = 2)
 
+      if (length(ssbtarg) > 0){
       # relative ssb
       ## relative ssb min
       rel.ssb.min <- (ssb.min / ssbtarg) |>
@@ -248,6 +249,20 @@ add_more_key_quants <- function(
       ## relative ssb max
       rel.ssb.max <- (ssb.max / ssbtarg) |>
         round(digits = 2)
+
+      # replace rel.ssb.min, max placeholders within topic_cap_alt
+      topic_cap_alt <- topic_cap_alt |>
+        dplyr::mutate(alt_text = stringr::str_replace_all(
+          alt_text,
+          "rel.ssb.min",
+          as.character(rel.ssb.min)
+        )) |>
+        dplyr::mutate(alt_text = stringr::str_replace_all(
+          alt_text,
+          "rel.ssb.max",
+          as.character(rel.ssb.max)
+        ))
+      }
 
       # replace sr.ssb.min, sr.ssb.max, ssbtarg, ssb.min, and ssb.max placeholders
       # within topic_cap_alt
@@ -261,16 +276,6 @@ add_more_key_quants <- function(
           alt_text,
           "sr.ssb.max",
           as.character(sr.ssb.max)
-        )) |>
-        dplyr::mutate(alt_text = stringr::str_replace_all(
-          alt_text,
-          "rel.ssb.min",
-          as.character(rel.ssb.min)
-        )) |>
-        dplyr::mutate(alt_text = stringr::str_replace_all(
-          alt_text,
-          "rel.ssb.max",
-          as.character(rel.ssb.max)
         )) |>
         # putting these last so they won't sub in for rel.ssb.min/max
         dplyr::mutate(alt_text = stringr::str_replace_all(

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@ check_year <- function(end_year = NULL,
 # substitute in more key quantities (units, end_years, reference points, and more)
 # to captions/alt text
 add_more_key_quants <- function(
-    dat = NULL,
+    dat,
     topic = topic_label,
     fig_or_table = fig_or_table,
     dir = NULL,
@@ -167,8 +167,79 @@ add_more_key_quants <- function(
     }
   }
 
+  ## relative spawning biomass
+  if (topic_cap_alt$label == "relative.spawning.biomass") {
+    if (is.null(dat)) {
+      message("Some key quantities associated with relative spawning biomass were not extracted and added to captions_alt_text.csv due to missing data file (i.e., 'dat' argument).")
+    }
+    if (is.null(ref_line)){
+      message("ref_line was not provided. ssbtarg, rel.ssb.min, and rel.ssb.max were not calculated.")
+    } else {
+      # ssbtarg
+      ssbtarg <- dat |>
+        dplyr::filter(c(grepl(glue::glue('^spawning_biomass_{ref_line}$'), label) |
+                          grepl(glue::glue('^spawning_biomass_msy$'), label))) |>
+        dplyr::pull(estimate) |>
+        as.numeric() |>
+        round(digits = 2)
+
+      if (length(ssbtarg) > 0){
+        message("ssbtarg, rel.ssb.min, and rel.ssb.max were not calculated. Check your ref_line is accurate.")
+      } else {
+        # ssb.min and ssb.max can be calculated in write_captions, but these quants
+        # are needed for rel values below, so including them here instead
+        # minimum ssb
+        ssb.min <- dat |>
+          dplyr::filter(
+            label == "spawning_biomass",
+            module_name %in% c("DERIVED_QUANTITIES", "t.series")
+          ) |>
+          dplyr::slice(which.min(estimate)) |>
+          dplyr::select(estimate) |>
+          as.numeric() |>
+          round(digits = 2)
+
+        # maximum ssb
+        ssb.max <- dat |>
+          dplyr::filter(
+            label == "spawning_biomass",
+            module_name %in% c("DERIVED_QUANTITIES", "t.series")
+          ) |>
+          dplyr::slice(which.max(estimate)) |>
+          dplyr::select(estimate) |>
+          as.numeric() |>
+          round(digits = 2)
+
+        # relative ssb
+          ## relative ssb min
+          rel.ssb.min <- (ssb.min / ssbtarg) |>
+            round(digits = 2)
+
+          ## relative ssb max
+          rel.ssb.max <- (ssb.max / ssbtarg) |>
+            round(digits = 2)
+
+          # replace rel.ssb.min, max placeholders within topic_cap_alt
+          topic_cap_alt <- topic_cap_alt |>
+            dplyr::mutate(alt_text = stringr::str_replace_all(
+              alt_text,
+              "rel.ssb.min",
+              as.character(rel.ssb.min)
+            )) |>
+            dplyr::mutate(alt_text = stringr::str_replace_all(
+              alt_text,
+              "rel.ssb.max",
+              as.character(rel.ssb.max)
+            ))
+
+          message(paste0("rel.ssb.min: ", as.character(rel.ssb.min)))
+          message(paste0("rel.ssb.max: ", as.character(rel.ssb.max)))
+        }
+      }
+    }
+
   ## spawning biomass
-  if (topic_cap_alt$label %in% c("spawning.biomass", "relative.spawning.biomass")) {
+  if (topic_cap_alt$label == "spawning.biomass") {
     if (is.null(dat)) {
       message("Some key quantities associated with spawning biomass were not extracted and added to captions_alt_text.csv due to missing data file (i.e., 'dat' argument).")
     } else {
@@ -239,33 +310,6 @@ add_more_key_quants <- function(
         dplyr::select(estimate) |>
         as.numeric() |>
         round(digits = 2)
-
-      if (length(ssbtarg) > 0){
-      # relative ssb
-      ## relative ssb min
-      rel.ssb.min <- (ssb.min / ssbtarg) |>
-        round(digits = 2)
-
-      ## relative ssb max
-      rel.ssb.max <- (ssb.max / ssbtarg) |>
-        round(digits = 2)
-
-      # replace rel.ssb.min, max placeholders within topic_cap_alt
-      topic_cap_alt <- topic_cap_alt |>
-        dplyr::mutate(alt_text = stringr::str_replace_all(
-          alt_text,
-          "rel.ssb.min",
-          as.character(rel.ssb.min)
-        )) |>
-        dplyr::mutate(alt_text = stringr::str_replace_all(
-          alt_text,
-          "rel.ssb.max",
-          as.character(rel.ssb.max)
-        ))
-
-      message(paste0("rel.ssb.min: ", as.character(rel.ssb.min)))
-      message(paste0("rel.ssb.max: ", as.character(rel.ssb.max)))
-      }
 
       # replace sr.ssb.min, sr.ssb.max, ssbtarg, ssb.min, and ssb.max placeholders
       # within topic_cap_alt

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@ check_year <- function(end_year = NULL,
 # substitute in more key quantities (units, end_years, reference points, and more)
 # to captions/alt text
 add_more_key_quants <- function(
-    dat,
+    dat = NULL,
     topic = topic_label,
     fig_or_table = fig_or_table,
     dir = NULL,

--- a/R/utils.R
+++ b/R/utils.R
@@ -210,8 +210,8 @@ add_more_key_quants <- function(
 
       # ssbtarg
       ssbtarg <- dat |>
-        dplyr::filter(c(grepl('spawning_biomass_{ref_line}', label) |
-                          label == 'spawning_biomass_msy$')) |>
+        dplyr::filter(c(grepl(glue::glue('^spawning_biomass_{ref_line}$'), label) |
+                          grepl(glue::glue('^spawning_biomass_msy$'), label))) |>
         dplyr::pull(estimate) |>
         as.numeric() |>
         round(digits = 2)
@@ -261,6 +261,16 @@ add_more_key_quants <- function(
           alt_text,
           "sr.ssb.max",
           as.character(sr.ssb.max)
+        )) |>
+        dplyr::mutate(alt_text = stringr::str_replace_all(
+          alt_text,
+          "rel.ssb.min",
+          as.character(rel.ssb.min)
+        )) |>
+        dplyr::mutate(alt_text = stringr::str_replace_all(
+          alt_text,
+          "rel.ssb.max",
+          as.character(rel.ssb.max)
         )) |>
         # putting these last so they won't sub in for rel.ssb.min/max
         dplyr::mutate(alt_text = stringr::str_replace_all(

--- a/R/write_captions.R
+++ b/R/write_captions.R
@@ -603,46 +603,22 @@ write_captions <- function(dat, # converted model output object
     # ssb.units : added with add_more_key_quants
 
     # minimum ssb
-    ssb.min <- dat |>
-      dplyr::filter(
-        label == "spawning_biomass",
-        module_name %in% c("DERIVED_QUANTITIES", "t.series")
-      ) |>
-      dplyr::slice(which.min(estimate)) |>
-      dplyr::select(estimate) |>
-      as.numeric() |>
-      round(digits = 2)
+    # ssb.min : added with add_more_key_quants
 
     # maximum ssb
-    ssb.max <- dat |>
-      dplyr::filter(
-        label == "spawning_biomass",
-        module_name %in% c("DERIVED_QUANTITIES", "t.series")
-      ) |>
-      dplyr::slice(which.max(estimate)) |>
-      dplyr::select(estimate) |>
-      as.numeric() |>
-      round(digits = 2)
+    # ssb.max : added with add_more_key_quants
 
     # ssb reference point
     # ssb.ref.pt : added with add_more_key_quants
 
-    # TODO: uncomment and recode once we get clarity about how to extract this value properly
-    # ssbtarg <- dat |>
-    #   dplyr::filter(c(grepl('spawning_biomass', label) & grepl('msy$', label) & estimate >1) | label == 'spawning_biomass_msy$') |>
-    #   dplyr::pull(estimate) |>
-    #   as.numeric() |>
-    #   round(digits = 2)
+    # ssbtarg : added with add_more_key_quants
 
-    # TODO: uncomment and recode once we get clarity about how to extract ssbtarg properly
     ## relative ssb
     # relative ssb min
-    # rel.ssb.min <- (ssb.min / ssbtarg) |>
-    #   round(digits = 2)
-    #
-    # # relative ssb max
-    # rel.ssb.max <- (ssb.max / ssbtarg) |>
-    #   round(digits = 2)
+    # rel.ssb.min : added with add_more_key_quants
+
+    # relative ssb max
+    # rel.ssb.max : added with add_more_key_quants
 
 
     ## spr (spawning potential ratio)
@@ -921,18 +897,8 @@ write_captions <- function(dat, # converted model output object
       "recruit.dev.min" = as.character(recruit.dev.min),
       "recruit.dev.max" = as.character(recruit.dev.max),
 
-      # relative ssb
-      # NOTE: moving this above recruitment so rel.ssb.min isn't changed to
-      # "rel." + ssb.min), etc.
-      #  'rel.ssb.min' = as.character(rel.ssb.min),
-      #  'rel.ssb.max' = as.character(rel.ssb.max),
-
       ## spawning.biomass (ssb)
       "ssb.start.year" = as.character(ssb.start.year),
-      "ssb.min" = as.character(ssb.min),
-      "ssb.max" = as.character(ssb.max),
-      # 'ssbtarg' = as.character(ssbtarg),
-
 
       ## spr (spawning potential ratio)
       "spr.min" = as.character(spr.min),

--- a/man/plot_spawning_biomass.Rd
+++ b/man/plot_spawning_biomass.Rd
@@ -6,7 +6,7 @@
 \usage{
 plot_spawning_biomass(
   dat,
-  unit_label = "metric ton",
+  unit_label = "metric tons",
   scale_amount = 1,
   ref_line = c("target", "unfished", "msy"),
   ref_point = NULL,


### PR DESCRIPTION
move ssbtarg, ssb.min, ssb.max, rel.ssb.min, and rel.ssb.max from write_captions to add_more_key_quants so that ref_line can be used during calculations when it's added as an argument when running plot_spawning_biomass