### PR TITLE
Move ref_line labels to avoid getting cut off

### DIFF
--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -190,14 +190,12 @@ plot_biomass <- function(
       n.breaks = x_n_breaks,
       guide = ggplot2::guide_axis(minor.ticks = TRUE)
     ) +
-    ggplot2::annotate(
-      geom = "text",
-     # x = as.numeric(end_year) - 3,
-      x = max(b$year)-(0.2*length(b$year)),
-      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
+    ggplot2::geom_label(
+      x = max(b$year)-(0.1*length(b$year)),
+      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
       label = list(bquote(B[.(ref_line)])),
       parse = TRUE,
-      fill = "white"
+      label.size = 0
     ) +
     ggplot2::expand_limits(y = 0)
   # ggtext::geom_richtext(

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -189,8 +189,8 @@ plot_biomass <- function(
     ) +
     ggplot2::annotate(
       geom = "text",
-      x = as.numeric(end_year) + 0.05,
-      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+      x = as.numeric(end_year) - 3,
+      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
       label = list(bquote(B[.(ref_line)])),
       parse = TRUE,
       fill = "white"

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -156,7 +156,7 @@ plot_biomass <- function(
   # Choose number of breaks for x-axis
   x_n_breaks <- round(length(b[["year"]]) / 10)
   if (x_n_breaks <= 5) {
-    x_n_breaks <- round(length(b[["year"]]) / 5)
+    x_n_breaks <- length(b[["year"]])
   } else if (x_n_breaks > 10) {
     x_n_breaks <- round(length(b[["year"]]) / 15)
   }
@@ -192,12 +192,10 @@ plot_biomass <- function(
     ) +
     ggplot2::annotate(
       geom = "text",
-     # x = as.numeric(end_year) - 3,
-      x = max(b$year)-(0.2*length(b$year)),
-      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
+      x = as.numeric(end_year)-(0.2*length(b$year)),
+      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
       label = list(bquote(B[.(ref_line)])),
-      parse = TRUE,
-      fill = "white"
+      parse = TRUE
     ) +
     ggplot2::expand_limits(y = 0)
   # ggtext::geom_richtext(

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -132,6 +132,9 @@ plot_biomass <- function(
     end_year <- format(Sys.Date(), "%Y")
   }
 
+  b <- b |>
+    dplyr::filter(year <= end_year)
+
   # create plot-specific variables to use throughout fxn for naming and IDing
   # Indicate if biomass is relative or not
   if (relative) {
@@ -159,7 +162,7 @@ plot_biomass <- function(
   }
 
   # plot
-  plt <- ggplot2::ggplot(data = subset(b, year <= end_year)) +
+  plt <- ggplot2::ggplot(data = b) +
     ggplot2::geom_line(
       ggplot2::aes(
         x = year,

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -189,7 +189,8 @@ plot_biomass <- function(
     ) +
     ggplot2::annotate(
       geom = "text",
-      x = as.numeric(end_year) - 3,
+     # x = as.numeric(end_year) - 3,
+      x = max(b$year)-(0.2*length(b$year)),
       y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
       label = list(bquote(B[.(ref_line)])),
       parse = TRUE,

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -190,12 +190,14 @@ plot_biomass <- function(
       n.breaks = x_n_breaks,
       guide = ggplot2::guide_axis(minor.ticks = TRUE)
     ) +
-    ggplot2::geom_label(
-      x = max(b$year)-(0.1*length(b$year)),
-      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+    ggplot2::annotate(
+      geom = "text",
+     # x = as.numeric(end_year) - 3,
+      x = max(b$year)-(0.2*length(b$year)),
+      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
       label = list(bquote(B[.(ref_line)])),
       parse = TRUE,
-      label.size = 0
+      fill = "white"
     ) +
     ggplot2::expand_limits(y = 0)
   # ggtext::geom_richtext(

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -197,12 +197,13 @@ plot_spawning_biomass <- function(
       n.breaks = x_n_breaks,
       guide = ggplot2::guide_axis(minor.ticks = TRUE)
     ) +
-    ggplot2::geom_label(
-      x = max(sb$year)-(0.1*length(sb$year)),
-      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+    ggplot2::annotate(
+      geom = "text",
+      # x = as.numeric(end_year) - 3,
+      x = max(sb$year)-(0.2*length(sb$year)),
+      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
       label = list(bquote(SB[.(ref_line)])),
-      parse = TRUE,
-      label.size = 0
+      parse = TRUE
     ) +
     ggplot2::expand_limits(y = 0)
 

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -199,9 +199,8 @@ plot_spawning_biomass <- function(
     ) +
     ggplot2::annotate(
       geom = "text",
-      # x = as.numeric(end_year) - 3,
-      x = max(sb$year)-(0.2*length(sb$year)),
-      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
+      x = as.numeric(end_year)-(0.2*length(sb$year)),
+      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
       label = list(bquote(SB[.(ref_line)])),
       parse = TRUE
     ) +

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -197,13 +197,12 @@ plot_spawning_biomass <- function(
       n.breaks = x_n_breaks,
       guide = ggplot2::guide_axis(minor.ticks = TRUE)
     ) +
-    ggplot2::annotate(
-      geom = "text",
-      # x = as.numeric(end_year) - 3,
-      x = max(sb$year)-(0.2*length(sb$year)),
-      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
+    ggplot2::geom_label(
+      x = max(sb$year)-(0.1*length(sb$year)),
+      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
       label = list(bquote(SB[.(ref_line)])),
-      parse = TRUE
+      parse = TRUE,
+      label.size = 0
     ) +
     ggplot2::expand_limits(y = 0)
 

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -199,8 +199,8 @@ plot_spawning_biomass <- function(
     ) +
     ggplot2::annotate(
       geom = "text",
-      x = as.numeric(end_year) + 0.05,
-      y = ref_line_val / ifelse(relative, ref_line_val, scale_amount),
+      x = as.numeric(end_year) - 3,
+      y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
       label = list(bquote(SB[.(ref_line)])),
       parse = TRUE
     ) +

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -199,7 +199,8 @@ plot_spawning_biomass <- function(
     ) +
     ggplot2::annotate(
       geom = "text",
-      x = as.numeric(end_year) - 3,
+      # x = as.numeric(end_year) - 3,
+      x = max(sb$year)-(0.2*length(sb$year)),
       y = (ref_line_val / ifelse(relative, ref_line_val, scale_amount)) - 1,
       label = list(bquote(SB[.(ref_line)])),
       parse = TRUE


### PR DESCRIPTION
Slight adjustments to the B and SB labels left and down to avoid getting cut off, especially with longer ref line labels like "unfished", as per https://github.com/nmfs-ost/stockplotr/issues/102