### PR TITLE
Cleanup pkg: export_rda

### DIFF
--- a/R/export_rda.R
+++ b/R/export_rda.R
@@ -3,7 +3,7 @@
 #' Export a figure/table, and its caption and alternative text, to an rda object.
 #' Typically used after stockplotr::extract_caps_alttext().
 #'
-#' @param final The final figure (ggplot) or table (flextable) object.
+#' @param object The figure (ggplot) or table (flextable) object to be exported.
 #' @param caps_alttext The object containing a figure's caption and alternative
 #' text, in a list, or a table's caption, likely generated with
 #' stockplotr::extract_caps_alttext().
@@ -24,7 +24,7 @@
 #' @examples
 #' \dontrun{
 #' export_rda(
-#'   final = final_table_object,
+#'   object = final_table_object,
 #'   caps_alttext = caps_alttext_object,
 #'   figures_tables_dir = here::here(),
 #'   topic_label = "bnc",
@@ -32,14 +32,14 @@
 #' )
 #'
 #' export_rda(
-#'   final = final_figure_object,
+#'   object = final_figure_object,
 #'   caps_alttext = another_caps_alttext_object,
 #'   figures_tables_dir = "my_figures_tables_dir",
 #'   topic_label = "landings",
 #'   fig_or_table = "figure"
 #' )
 #' }
-export_rda <- function(final = NULL,
+export_rda <- function(object = NULL,
                        caps_alttext = NULL,
                        figures_tables_dir = NULL,
                        topic_label = NULL,
@@ -47,7 +47,7 @@ export_rda <- function(final = NULL,
   # make rda for figures
   if (fig_or_table == "figure") {
     rda <- list(
-      "figure" = final,
+      "figure" = object,
       "cap" = caps_alttext[[1]],
       "alt_text" = caps_alttext[[2]]
     )
@@ -62,7 +62,7 @@ export_rda <- function(final = NULL,
     # make rda for tables
   } else if (fig_or_table == "table") {
     rda <- list(
-      "table" = final,
+      "table" = object,
       "cap" = caps_alttext[[1]]
     )
     rda_loc <- "tables"

--- a/R/export_rda.R
+++ b/R/export_rda.R
@@ -7,14 +7,15 @@
 #' @param caps_alttext The object containing a figure's caption and alternative
 #' text, in a list, or a table's caption, likely generated with
 #' stockplotr::extract_caps_alttext().
-#' @param figures_tables_dir If the user has already created folders containing
-#' figures and tables ("figures" and "tables"), figures_tables_dir represents
-#' the location of these folders. Otherwise, these two folders will be created
-#' automatically, then used to store the exported rda files.
 #' @param topic_label A string that describes a figure or table's label. These
 #' labels are found in the "label" column of the "captions_alt_text.csv" file
 #' and are used to link the figure or table with its caption/alt text.
 #' @param fig_or_table A string describing whether the plot is a figure or table.
+#' @param figures_tables_dir If the user has already created folders containing
+#' figures and tables ("figures" and "tables"), figures_tables_dir represents
+#' the location of these folders. Otherwise, these two folders will be created
+#' automatically, then used to store the exported rda files. Default is the 
+#' working directory.
 #'
 #' @return An rda file with a figure's ggplot, caption, and alternative text, or
 #' a table's flextable and caption.
@@ -26,24 +27,25 @@
 #' export_rda(
 #'   object = final_table_object,
 #'   caps_alttext = caps_alttext_object,
-#'   figures_tables_dir = here::here(),
 #'   topic_label = "bnc",
-#'   fig_or_table = "table"
+#'   fig_or_table = "table",
+#'   figures_tables_dir = here::here()
 #' )
 #'
 #' export_rda(
 #'   object = final_figure_object,
 #'   caps_alttext = another_caps_alttext_object,
-#'   figures_tables_dir = "my_figures_tables_dir",
 #'   topic_label = "landings",
-#'   fig_or_table = "figure"
+#'   fig_or_table = "figure",
+#'   figures_tables_dir = "my_figures_tables_dir"
 #' )
 #' }
-export_rda <- function(object = NULL,
-                       caps_alttext = NULL,
-                       figures_tables_dir = NULL,
-                       topic_label = NULL,
-                       fig_or_table = NULL) {
+export_rda <- function(object,
+                       caps_alttext,
+                       topic_label,
+                       fig_or_table,
+                       figures_tables_dir = getwd()
+                       ) {
   # make rda for figures
   if (fig_or_table == "figure") {
     rda <- list(

--- a/R/plot_abundance_at_age.R
+++ b/R/plot_abundance_at_age.R
@@ -226,7 +226,7 @@ plot_abundance_at_age <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -244,7 +244,7 @@ plot_biomass <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_biomass_at_age.R
+++ b/R/plot_biomass_at_age.R
@@ -196,7 +196,7 @@ plot_biomass_at_age <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_indices.R
+++ b/R/plot_indices.R
@@ -194,7 +194,7 @@ plot_indices <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_landings.R
+++ b/R/plot_landings.R
@@ -158,7 +158,7 @@ plot_landings <- function(dat,
   # export figure to rda if argument = T
   if (make_rda == TRUE) {
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_recruitment.R
+++ b/R/plot_recruitment.R
@@ -176,7 +176,7 @@ plot_recruitment <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_recruitment_deviations.R
+++ b/R/plot_recruitment_deviations.R
@@ -142,7 +142,7 @@ plot_recruitment_deviations <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_spawn_recruitment.R
+++ b/R/plot_spawn_recruitment.R
@@ -131,7 +131,7 @@ plot_spawn_recruitment <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -244,7 +244,7 @@ plot_spawning_biomass <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = figures_dir,
       topic_label = topic_label,

--- a/R/table_bnc.R
+++ b/R/table_bnc.R
@@ -185,7 +185,7 @@ table_bnc <- function(
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = tables_dir,
       topic_label = topic_label,

--- a/R/table_indices.R
+++ b/R/table_indices.R
@@ -161,7 +161,7 @@ table_indices <- function(
 
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = tables_dir,
       topic_label = topic_label,

--- a/R/table_landings.R
+++ b/R/table_landings.R
@@ -200,7 +200,7 @@ table_landings <- function(dat,
     )
 
     export_rda(
-      final = final,
+      object = final,
       caps_alttext = caps_alttext,
       figures_tables_dir = tables_dir,
       topic_label = topic_label,

--- a/man/export_rda.Rd
+++ b/man/export_rda.Rd
@@ -5,11 +5,11 @@
 \title{Export a figure or table to rda}
 \usage{
 export_rda(
-  object = NULL,
-  caps_alttext = NULL,
-  figures_tables_dir = NULL,
-  topic_label = NULL,
-  fig_or_table = NULL
+  object,
+  caps_alttext,
+  topic_label,
+  fig_or_table,
+  figures_tables_dir = getwd()
 )
 }
 \arguments{
@@ -19,16 +19,17 @@ export_rda(
 text, in a list, or a table's caption, likely generated with
 stockplotr::extract_caps_alttext().}
 
-\item{figures_tables_dir}{If the user has already created folders containing
-figures and tables ("figures" and "tables"), figures_tables_dir represents
-the location of these folders. Otherwise, these two folders will be created
-automatically, then used to store the exported rda files.}
-
 \item{topic_label}{A string that describes a figure or table's label. These
 labels are found in the "label" column of the "captions_alt_text.csv" file
 and are used to link the figure or table with its caption/alt text.}
 
 \item{fig_or_table}{A string describing whether the plot is a figure or table.}
+
+\item{figures_tables_dir}{If the user has already created folders containing
+figures and tables ("figures" and "tables"), figures_tables_dir represents
+the location of these folders. Otherwise, these two folders will be created
+automatically, then used to store the exported rda files. Default is the 
+working directory.}
 }
 \value{
 An rda file with a figure's ggplot, caption, and alternative text, or
@@ -43,17 +44,17 @@ Typically used after stockplotr::extract_caps_alttext().
 export_rda(
   object = final_table_object,
   caps_alttext = caps_alttext_object,
-  figures_tables_dir = here::here(),
   topic_label = "bnc",
-  fig_or_table = "table"
+  fig_or_table = "table",
+  figures_tables_dir = here::here()
 )
 
 export_rda(
   object = final_figure_object,
   caps_alttext = another_caps_alttext_object,
-  figures_tables_dir = "my_figures_tables_dir",
   topic_label = "landings",
-  fig_or_table = "figure"
+  fig_or_table = "figure",
+  figures_tables_dir = "my_figures_tables_dir"
 )
 }
 }

--- a/man/export_rda.Rd
+++ b/man/export_rda.Rd
@@ -5,7 +5,7 @@
 \title{Export a figure or table to rda}
 \usage{
 export_rda(
-  final = NULL,
+  object = NULL,
   caps_alttext = NULL,
   figures_tables_dir = NULL,
   topic_label = NULL,
@@ -13,7 +13,7 @@ export_rda(
 )
 }
 \arguments{
-\item{final}{The final figure (ggplot) or table (flextable) object.}
+\item{object}{The figure (ggplot) or table (flextable) object to be exported.}
 
 \item{caps_alttext}{The object containing a figure's caption and alternative
 text, in a list, or a table's caption, likely generated with
@@ -41,7 +41,7 @@ Typically used after stockplotr::extract_caps_alttext().
 \examples{
 \dontrun{
 export_rda(
-  final = final_table_object,
+  object = final_table_object,
   caps_alttext = caps_alttext_object,
   figures_tables_dir = here::here(),
   topic_label = "bnc",
@@ -49,7 +49,7 @@ export_rda(
 )
 
 export_rda(
-  final = final_figure_object,
+  object = final_figure_object,
   caps_alttext = another_caps_alttext_object,
   figures_tables_dir = "my_figures_tables_dir",
   topic_label = "landings",

--- a/tests/testthat/test-export_rda.R
+++ b/tests/testthat/test-export_rda.R
@@ -29,7 +29,7 @@ test_that("export_rda works for figures", {
 
   # export rda
   export_rda(
-    final = final,
+    object = final,
     caps_alttext = caps_alttext,
     figures_tables_dir = getwd(),
     topic_label = topic_label,
@@ -73,7 +73,7 @@ test_that("export_rda works for tables", {
 
   # export rda
   export_rda(
-    final = final,
+    object = final,
     caps_alttext = caps_alttext,
     figures_tables_dir = getwd(),
     topic_label = topic_label,


### PR DESCRIPTION
Address updates noted in export_rda section of https://github.com/nmfs-ost/stockplotr/issues/112

- I didn't make defaults from most args. I didn't think it made sense because the function exports rdas for specific plots, which require specific arguments to identify the plot name, table or figure identification, etc.