### PR TITLE
[Hotfix]: move Quarto to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,6 @@ Imports:
     naniar,
     prodlim,
     purrr,
-    quarto,
     rlang,
     scales,
     stats,
@@ -61,6 +60,7 @@ Imports:
 Suggests:
     here,
     knitr,
+    quarto,
     rmarkdown,
     testthat (>= 3.0.0)
 VignetteBuilder: 


### PR DESCRIPTION
Moving quarto to suggest since html_all_figs_tables isn't really used at the moment and we plan to do an overhaul of the function that won't depend on quarto anymore

**Merge after SEFSC workshop**