### PR TITLE
Update save_all_plots() to export landings table

### DIFF
--- a/R/save_all_plots.R
+++ b/R/save_all_plots.R
@@ -181,7 +181,6 @@ save_all_plots <- function(
       cli::cli_h2("plot_fishing_mortality")
       plot_fishing_mortality(dat,
         make_rda = TRUE,
-        relative = relative,
         figures_dir = figures_tables_dir,
         interactive = FALSE
       ) # |>
@@ -414,24 +413,25 @@ save_all_plots <- function(
   #   }
   # )
 
-  # tryCatch(
-  #   {
-  #     cli::cli_h2("table_landings")
-  #     table_landings(dat,
-  #       unit_label = landings_unit_label,
-  #       make_rda = TRUE,
-  #       tables_dir = figures_tables_dir
-  #     ) # |>
-  #     # suppressWarnings() |>
-  #     # invisible()
-  #   },
-  #   error = function(e) {
-  #     cli::cli_alert_danger("table_landings failed to run.")
-  #     cli::cli_alert("Tip: check that your arguments are correct.")
-  #     cli::cli_li("landings_unit_label = {landings_unit_label}")
-  #     print(e)
-  #   }
-  # )
+  tryCatch(
+    {
+      cli::cli_h2("table_landings")
+      table_landings(dat,
+        unit_label = landings_unit_label,
+        interactive = FALSE,
+        make_rda = TRUE,
+        tables_dir = figures_tables_dir
+      ) # |>
+      # suppressWarnings() |>
+      # invisible()
+    },
+    error = function(e) {
+      cli::cli_alert_danger("table_landings failed to run.")
+      cli::cli_alert("Tip: check that your arguments are correct.")
+      cli::cli_li("landings_unit_label = {landings_unit_label}")
+      print(e)
+    }
+  )
 
   # uncomment when finished
   #

--- a/tests/testthat/test-save_all_plots.R
+++ b/tests/testthat/test-save_all_plots.R
@@ -18,7 +18,7 @@ test_that("save_all_plots works when all figures/tables are plotted", {
 
   # expect that the figures and tables dirs exist
   expect_true(dir.exists(fs::path(getwd(), "figures")))
-  # expect_true(dir.exists(fs::path(getwd(), "tables")))
+  expect_true(dir.exists(fs::path(getwd(), "tables")))
 
   # expect that the figures are all created with expected names
   fig_base_temp_files <- c(
@@ -40,20 +40,20 @@ test_that("save_all_plots works when all figures/tables are plotted", {
     sort(fig_base_temp_files)
   )
 
-  # # expect that the tables are all created with expected names
-  #  tab_base_temp_files <- c(
-  #   # "bnc_table.rda",
-  #  #  "indices.abundance_table.rda",
-  #    "landings_table.rda"
-  #  )
-  #  expect_equal(
-  #    list.files(fs::path(getwd(), "tables")),
-  #    tab_base_temp_files
-  #  )
+  # expect that the tables are all created with expected names
+   tab_base_temp_files <- c(
+    # "bnc_table.rda",
+   #  "indices.abundance_table.rda",
+     "landings_table.rda"
+   )
+   expect_equal(
+     list.files(fs::path(getwd(), "tables")),
+     tab_base_temp_files
+   )
 
   # erase temporary testing files
   file.remove(fs::path(getwd(), "captions_alt_text.csv"))
   file.remove(fs::path(getwd(), "key_quantities.csv"))
   unlink(fs::path(getwd(), "figures"), recursive = T)
-  # unlink(fs::path(getwd(), "tables"), recursive = T)
+  unlink(fs::path(getwd(), "tables"), recursive = T)
 })


### PR DESCRIPTION
* Update `save_all_plots()` to export landings table
* Remove now-deprecated 'relative' arg from `plot_fishing_mortality()` in `save_all_plots()`