### PR TITLE
[Fix]: remove grouping override

### DIFF
--- a/R/plot_recruitment_deviations.R
+++ b/R/plot_recruitment_deviations.R
@@ -54,7 +54,7 @@ plot_recruitment_deviations <- function(
     dat = filter_data,
     group = "none",
     facet = NULL,
-    method = "avg"
+    method = "mean"
   )
   filter_data <- processed_data[[1]]
   group <- processed_data[[2]]
@@ -76,31 +76,6 @@ plot_recruitment_deviations <- function(
   ) +
     # ggplot2::facet_wrap(~ model, scales = "free_y") +
     theme_noaa()
-
-  # Plot vertical lines if era is not filtering
-  # if (is.null(era)) {
-  #   # Find unique era
-  #   eras <- unique(filter_data$era)
-  #   if (length(eras) > 1) {
-  #     # era1 <- filter_data |>
-  #     #   dplyr::filter(era == eras[1]) |>
-  #     #   dplyr::pull(year) |>
-  #     #   max(na.rm = TRUE)
-  #     year_vlines <- c()
-  #     for (i in 2:length(eras)) {
-  #       erax <- filter_data |>
-  #         dplyr::filter(era == eras[i]) |>
-  #         dplyr::pull(year) |>
-  #         min(na.rm = TRUE)
-  #       year_vlines <- c(year_vlines, erax)
-  #     }
-  #   }
-  #   final <- final +
-  #     ggplot2::geom_vline(
-  #       xintercept = year_vlines,
-  #       color = "#999999"
-  #     )
-  # }
 
   # Make RDA
   if (make_rda) {

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -91,29 +91,30 @@ process_data <- function(
   # check for additional indexed variables
   index_variables <- check_grouping(dat)
   # If user input "none" to group this makes the plot remove any facetting or summarize?
-  if (!is.null(group) && group == "none") {
-    # group <- NULL
-    id_group <- index_variables[-grepl("year|age", index_variables)]
-    index_variables <- intersect(c("year", "age"), index_variables)
-    if (length(id_group) > 0) {
-      dat <- switch(method,
-        "mean" = dat |>
-          dplyr::group_by(dplyr::across(tidyselect::all_of(c("label", "model", "group_var", index_variables)))) |>
-          dplyr::summarize(
-            estimate = mean(estimate),
-            estimate_lower = mean(estimate_lower),
-            estimate_upper = mean(estimate_upper)
-          ),
-        "sum" = dat |>
-          dplyr::group_by(dplyr::across(tidyselect::all_of(c("label", "model", "group_var", index_variables)))) |>
-          dplyr::summarize(
-            estimate = sum(estimate),
-            estimate_lower = sum(estimate_lower),
-            estimate_upper = sum(estimate_upper)
-          )
-      )
-    }
-  }
+  # Removing this bc this logic has a lot of flaws
+  # if (!is.null(group) && group == "none") {
+  #   # group <- NULL
+  #   id_group <- index_variables[-grepl("year|age", index_variables)]
+  #   index_variables <- intersect(c("year", "age"), index_variables)
+  #   if (length(id_group) > 0) {
+  #     dat <- switch(method,
+  #       "mean" = dat |>
+  #         dplyr::group_by(dplyr::across(tidyselect::all_of(c("label", "model", "group_var", index_variables)))) |>
+  #         dplyr::summarize(
+  #           estimate = mean(estimate),
+  #           estimate_lower = mean(estimate_lower),
+  #           estimate_upper = mean(estimate_upper)
+  #         ),
+  #       "sum" = dat |>
+  #         dplyr::group_by(dplyr::across(tidyselect::all_of(c("label", "model", "group_var", index_variables)))) |>
+  #         dplyr::summarize(
+  #           estimate = sum(estimate),
+  #           estimate_lower = sum(estimate_lower),
+  #           estimate_upper = sum(estimate_upper)
+  #         )
+  #     )
+  #   }
+  # }
   # Warn  user when group not indexed in data
   # if (!is.null(group) && group %notin% index_variables) {
   #   if (group != "none") {
@@ -126,7 +127,7 @@ process_data <- function(
   if (!is.null(group) && group != "none") {
     data <- dplyr::mutate(
       dat,
-      group_var = as.character(.data[[group]])
+      group_var = .data[[group]]
     )
     if (group %notin% index_variables) index_variables <- c(group, index_variables)
   } else {

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -128,6 +128,7 @@ process_data <- function(
       dat,
       group_var = .data[[group]]
     )
+    if (group %notin% index_variables) index_variables <- c(group, index_variables)
   } else {
     data <- dat
   }

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -126,7 +126,7 @@ process_data <- function(
   if (!is.null(group) && group != "none") {
     data <- dplyr::mutate(
       dat,
-      group_var = .data[[group]]
+      group_var = as.character(.data[[group]])
     )
     if (group %notin% index_variables) index_variables <- c(group, index_variables)
   } else {
@@ -343,7 +343,7 @@ process_data <- function(
   data <- data |>
     dplyr::mutate(
       across(
-        tidyselect::any_of(c(group, facet)),
+        tidyselect::any_of(c(group, facet, "group_var")),
         as.character
       )
     )

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -115,13 +115,13 @@ process_data <- function(
     }
   }
   # Warn  user when group not indexed in data
-  if (!is.null(group) && group %notin% index_variables) {
-    if (group != "none") {
-      cli::cli_alert_warning("{group} not an index of data.")
-      # reset group to NULL so it's not added to grouping incorrectly
-      group <- NULL
-    }
-  }
+  # if (!is.null(group) && group %notin% index_variables) {
+  #   if (group != "none") {
+  #     cli::cli_alert_warning("{group} not an index of data.")
+  #     # reset group to NULL so it's not added to grouping incorrectly
+  #     group <- NULL
+  #   }
+  # }
   # Set group_var to identified grouping
   if (!is.null(group) && group != "none") {
     data <- dplyr::mutate(

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -932,20 +932,20 @@ label_magnitude <- function(
 
 check_grouping <- function(dat) {
   # Identify potential indexing variables
-  # index_variables <- c(
-  #   "year", # also not sure of this one
-  #   "age", # not sure if want to add age here
-  #   "fleet", "sex",
-  #   "area", "growth_pattern", "month",
-  #   "season", "platoon", "bio_pattern",
-  #   "settlement", "morph", "block", "length_bins"
-  # )
-  non.index_variables <- c(
-    "estimate", "initial", "likelihood",
-    "uncertainty", "uncertainty_label",
-    "module_name", "label"
+  index_variables <- c(
+    "year", # also not sure of this one
+    "age", # not sure if want to add age here
+    "fleet", "sex",
+    "area", "growth_pattern", "month",
+    "season", "platoon", "bio_pattern",
+    "settlement", "morph", "block", "length_bins"
   )
-  index_variables <- colnames(dat)[-grep(paste0(non.index_variables, collapse = "|"), colnames(dat))]
+  # non.index_variables <- c(
+  #   "estimate", "initial", "likelihood",
+  #   "uncertainty", "uncertainty_label",
+  #   "module_name", "label"
+  # )
+  # index_variables <- colnames(dat)[-grep(paste0(non.index_variables, collapse = "|"), colnames(dat))]
   # Create emppty vector
   dat_index <- c()
   # Cycle through indexing variables and identify ones that have more than 1 unique value

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -932,14 +932,20 @@ label_magnitude <- function(
 
 check_grouping <- function(dat) {
   # Identify potential indexing variables
-  index_variables <- c(
-    "year", # also not sure of this one
-    "age", # not sure if want to add age here
-    "fleet", "sex",
-    "area", "growth_pattern", "month",
-    "season", "platoon", "bio_pattern",
-    "settlement", "morph", "block", "length_bins"
+  # index_variables <- c(
+  #   "year", # also not sure of this one
+  #   "age", # not sure if want to add age here
+  #   "fleet", "sex",
+  #   "area", "growth_pattern", "month",
+  #   "season", "platoon", "bio_pattern",
+  #   "settlement", "morph", "block", "length_bins"
+  # )
+  non.index_variables <- c(
+    "estimate", "initial", "likelihood",
+    "uncertainty", "uncertainty_label",
+    "module_name", "label"
   )
+  index_variables <- colnames(dat)[-grep(paste0(non.index_variables, collapse = "|"), colnames(dat))]
   # Create emppty vector
   dat_index <- c()
   # Cycle through indexing variables and identify ones that have more than 1 unique value

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -109,7 +109,11 @@ plot_timeseries <- function(
             ymax = estimate_upper,
             fill = {
               if (length(unique(.data[["model"]])) > 1) {
-                interaction(model, group_var)
+                if (length(unique(.data[["group_var"]])) == 1) {
+                  model
+                } else {
+                  interaction(model, group_var)
+                }
               } else {
                 group_var
               }

--- a/tests/testthat/test-plot_natural_mortality.R
+++ b/tests/testthat/test-plot_natural_mortality.R
@@ -4,10 +4,11 @@ test_that("plot_natural_mortality generate without errors", {
     plot_natural_mortality(stockplotr::example_data, module = "Natural_Mortality")
   )
 
+  # This check is moot with the more flextible approach and labelling?
   # expect eror when not interactive since it's choosing the first module in ex
-  expect_error(
-    plot_natural_mortality(stockplotr::example_data)
-  )
+  # expect_error(
+  #   plot_natural_mortality(stockplotr::example_data)
+  # )
 
   # expect ggplot object is returned
   expect_s3_class(


### PR DESCRIPTION
I am removing the code that overrides group when user input something that was not in the index variables. The function `check_grouping()` (internal) only matches a certain number of potential grouping variables so it will cause a plot to plot incorrectly when some other id variable is present. This removes this issue, but the error still persists unless the user puts the explicit  column name for grouping in the `group` argument. 

For example, group = "fleet" will be recognizes whether a user inputs the column as an argument or not. The column name "retrospective" will not be automatically detected as an index variable in group, so the plot will look off and not contain the information in the legend. But if the user explicitly states group = "retrospective" in the argument for the plot, it will plot correctly.