### PR TITLE
[feat]: enable user to add a reference line to the plot for each input dat

### DIFF
--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -141,37 +141,56 @@ plot_biomass <- function(
     ...
   )
   # Add reference line
+  # Conditions for ref line
+  # 1. all are comparing same value = msy, target, unfished...
+  # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+  # 3. input vector of labels = c("msy", "target")
   # getting data set - an ifelse statement in the fxn wasn't working
   if (relative) {
     # don't add any reference line here and just add theme for final plot
     final <- plt + theme_noaa()
   } else {
-    if ("unfished" %in% c(names(ref_line), ref_line)) {
-      # find the minimum x axis value from the plot
-      min_year <- min <- ggplot2::ggplot_build(plt)[["data"]][[2]] |>
-        as.data.frame() |>
-        dplyr::pull(x) |>
-        min() |>
-        round(digits = 2)
-      # find the reference point value for unfished
-      ref_point <- calculate_reference_point(
-        dat = stockplotr::example_data,
-        reference_name = "biomass_unfished"
-      ) / scale_amount
-      # add point to plot and add theme
-      final <- plt +
-        ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-        theme_noaa()
-    } else {
-      final <- reference_line(
-        plot = plt,
-        dat = rp_dat,
-        label_name = "biomass",
-        reference = ref_line,
-        scale_amount = scale_amount
-      ) +
-        theme_noaa()
+    plt2 <- plt
+    # Check if length of ref_line = dat
+    # replicate value if not
+    if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
+    # Put into for loop and add lines sequentially to plt
+    for (i in 1:length(ref_line)) {
+      # find the reference point value
+      if (is.null(names(ref_line[i]))) {
+        ref_line_x <- calculate_reference_point(
+          dat = dat[[i]],
+          reference_name = glue::glue("biomass_{ref_line[i]}"),
+          lbs = lbs
+        ) / scale_amount
+        ref_line_x <- setNames(ref_line_x, ref_line[i])
+      } else {
+        ref_line_x <- ref_line[i] / scale_amount
+      }
+      
+      if ("unfished" %in% names(ref_line_x)) {
+        # find the minimum x axis value from the plot
+        min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
+          as.data.frame() |>
+          dplyr::pull(x) |>
+          min() |>
+          round(digits = 2)
+        # add point to plot and add theme
+        plt2 <- plt2 +
+          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
+          theme_noaa()
+      } else {
+        # add apply/purrr/or for loop for reference lines -- not just the first anymore
+        plt2 <- plt2 +
+          reference_line(
+            # conditionally add label name
+            label_name = ifelse(length(names(ref_line)) == 1, "biomass", names(dat)[i]), #"spawning_biomass",
+            ref_line = ref_line_x,
+            scale_amount = 1
+          )
+      }
     }
+    final <- plt2 + theme_noaa()
   }
 
   ### Make RDA ----

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -156,7 +156,17 @@ plot_biomass <- function(
   }
   
   if (!is.data.frame(dat)) {
-    final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+    if (!is.null(names(ref_line))) {
+      if (any(
+        grepl(
+          glue::glue("^biomass_{ref_line}"),
+          # TODO: make this check more efficient
+          ifelse(is.data.frame(dat), dat[["label"]], sapply(dat, `[[`, "label"))
+        )
+      )) {
+        final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+      }
+    }
   }
 
   ### Make RDA ----

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -141,58 +141,19 @@ plot_biomass <- function(
     ...
   )
   # Add reference line
-  # Conditions for ref line
-  # 1. all are comparing same value = msy, target, unfished...
-  # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
-  # 3. input vector of labels = c("msy", "target")
-  # getting data set - an ifelse statement in the fxn wasn't working
   if (relative) {
     # don't add any reference line here and just add theme for final plot
     final <- plt + theme_noaa()
   } else {
-    plt2 <- plt
-    if (is.null(names(ref_line[i]))) {
-      # Check if length of ref_line = dat
-      # replicate value if not
-      if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
-      # Put into for loop and add lines sequentially to plt
-      for (i in 1:length(ref_line)) {
-        # find the reference point value
-        if (is.null(names(ref_line[i]))) {
-          ref_line_x <- calculate_reference_point(
-            dat = dat[[i]],
-            reference_name = glue::glue("biomass_{ref_line[i]}"),
-            lbs = lbs
-          ) / scale_amount
-          ref_line_x <- setNames(ref_line_x, ref_line[i])
-        } else {
-          ref_line_x <- ref_line[i] / scale_amount
-        }
-        
-        if ("unfished" %in% names(ref_line_x)) {
-          # find the minimum x axis value from the plot
-          min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
-            as.data.frame() |>
-            dplyr::pull(x) |>
-            min() |>
-            round(digits = 2)
-          # add point to plot and add theme
-          plt2 <- plt2 +
-            ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-            theme_noaa()
-        } else {
-          # add apply/purrr/or for loop for reference lines -- not just the first anymore
-          plt2 <- plt2 +
-            reference_line(
-              # conditionally add label name
-              label_name = ifelse(length(names(ref_line)) == 1, "biomass", names(dat)[i]), #"spawning_biomass",
-              ref_line = ref_line_x,
-              scale_amount = 1
-            )
-        }
-      }
-    }
-    final <- plt2 + theme_noaa()
+    final <- plt +
+      add_reference_line(
+        dat = dat, 
+        ref_line = ref_line, 
+        label = "biomass", 
+        lbs = lbs,
+        scale_amount = scale_amount
+      ) +
+      theme_noaa()
   }
 
   ### Make RDA ----

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -151,43 +151,45 @@ plot_biomass <- function(
     final <- plt + theme_noaa()
   } else {
     plt2 <- plt
-    # Check if length of ref_line = dat
-    # replicate value if not
-    if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
-    # Put into for loop and add lines sequentially to plt
-    for (i in 1:length(ref_line)) {
-      # find the reference point value
-      if (is.null(names(ref_line[i]))) {
-        ref_line_x <- calculate_reference_point(
-          dat = dat[[i]],
-          reference_name = glue::glue("biomass_{ref_line[i]}"),
-          lbs = lbs
-        ) / scale_amount
-        ref_line_x <- setNames(ref_line_x, ref_line[i])
-      } else {
-        ref_line_x <- ref_line[i] / scale_amount
-      }
-      
-      if ("unfished" %in% names(ref_line_x)) {
-        # find the minimum x axis value from the plot
-        min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
-          as.data.frame() |>
-          dplyr::pull(x) |>
-          min() |>
-          round(digits = 2)
-        # add point to plot and add theme
-        plt2 <- plt2 +
-          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-          theme_noaa()
-      } else {
-        # add apply/purrr/or for loop for reference lines -- not just the first anymore
-        plt2 <- plt2 +
-          reference_line(
-            # conditionally add label name
-            label_name = ifelse(length(names(ref_line)) == 1, "biomass", names(dat)[i]), #"spawning_biomass",
-            ref_line = ref_line_x,
-            scale_amount = 1
-          )
+    if (is.null(names(ref_line[i]))) {
+      # Check if length of ref_line = dat
+      # replicate value if not
+      if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
+      # Put into for loop and add lines sequentially to plt
+      for (i in 1:length(ref_line)) {
+        # find the reference point value
+        if (is.null(names(ref_line[i]))) {
+          ref_line_x <- calculate_reference_point(
+            dat = dat[[i]],
+            reference_name = glue::glue("biomass_{ref_line[i]}"),
+            lbs = lbs
+          ) / scale_amount
+          ref_line_x <- setNames(ref_line_x, ref_line[i])
+        } else {
+          ref_line_x <- ref_line[i] / scale_amount
+        }
+        
+        if ("unfished" %in% names(ref_line_x)) {
+          # find the minimum x axis value from the plot
+          min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
+            as.data.frame() |>
+            dplyr::pull(x) |>
+            min() |>
+            round(digits = 2)
+          # add point to plot and add theme
+          plt2 <- plt2 +
+            ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
+            theme_noaa()
+        } else {
+          # add apply/purrr/or for loop for reference lines -- not just the first anymore
+          plt2 <- plt2 +
+            reference_line(
+              # conditionally add label name
+              label_name = ifelse(length(names(ref_line)) == 1, "biomass", names(dat)[i]), #"spawning_biomass",
+              ref_line = ref_line_x,
+              scale_amount = 1
+            )
+        }
       }
     }
     final <- plt2 + theme_noaa()

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -154,6 +154,10 @@ plot_biomass <- function(
       ) +
       theme_noaa()
   }
+  
+  if (!is.data.frame(dat)) {
+    final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+  }
 
   ### Make RDA ----
   if (make_rda) {

--- a/R/plot_biomass.R
+++ b/R/plot_biomass.R
@@ -149,8 +149,7 @@ plot_biomass <- function(
       add_reference_line(
         dat = dat, 
         ref_line = ref_line, 
-        label = "biomass", 
-        lbs = lbs,
+        label = "biomass",
         scale_amount = scale_amount
       ) +
       theme_noaa()

--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -76,14 +76,58 @@ plot_fishing_mortality <- function(
     facet = facet,
     ...
   )
-  # Add reference line and theme
-  final <- reference_line(
-    plot = plt,
-    dat = dat,
-    label_name = "fishing_mortality",
-    reference = ref_line,
-    scale_amount = 1
-  ) + theme_noaa()
+  # Add reference line
+  # Conditions for ref line
+  # 1. all are comparing same value = msy, target, unfished...
+  # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+  # 3. input vector of labels = c("msy", "target")
+  # getting data set - an ifelse statement in the fxn wasn't working
+  if (relative) {
+    # don't add any reference line here and just add theme for final plot
+    final <- plt + theme_noaa()
+  } else {
+    plt2 <- plt
+    # Check if length of ref_line = dat
+    # replicate value if not
+    if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
+    # Put into for loop and add lines sequentially to plt
+    for (i in 1:length(ref_line)) {
+      # find the reference point value
+      if (is.null(names(ref_line[i]))) {
+        ref_line_x <- calculate_reference_point(
+          dat = dat[[i]],
+          reference_name = glue::glue("fishing_mortality_{ref_line[i]}"),
+          lbs = lbs
+        ) / scale_amount
+        ref_line_x <- setNames(ref_line_x, ref_line[i])
+      } else {
+        ref_line_x <- ref_line[i] / scale_amount
+      }
+      
+      if ("unfished" %in% names(ref_line_x)) {
+        # find the minimum x axis value from the plot
+        min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
+          as.data.frame() |>
+          dplyr::pull(x) |>
+          min() |>
+          round(digits = 2)
+        # add point to plot and add theme
+        plt2 <- plt2 +
+          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
+          theme_noaa()
+      } else {
+        # add apply/purrr/or for loop for reference lines -- not just the first anymore
+        plt2 <- plt2 +
+          reference_line(
+            # conditionally add label name
+            label_name = ifelse(length(names(ref_line)) == 1, "fishing_mortality", names(dat)[i]), #"spawning_biomass",
+            ref_line = ref_line_x,
+            scale_amount = 1
+          )
+      }
+    }
+    final <- plt2 + theme_noaa()
+  }
 
   ### Make RDA ----
   if (make_rda) {

--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -86,7 +86,17 @@ plot_fishing_mortality <- function(
       theme_noaa()
   
   if (!is.data.frame(dat)) {
-    final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+    if (!is.null(names(ref_line))) {
+      if (any(
+        grepl(
+          glue::glue("^fishing_mortality_{ref_line}"),
+          # TODO: make this check more efficient
+          ifelse(is.data.frame(dat), dat[["label"]], sapply(dat, `[[`, "label"))
+        )
+      )) {
+        final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+      }
+    }
   }
 
   ### Make RDA ----

--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -87,43 +87,45 @@ plot_fishing_mortality <- function(
     final <- plt + theme_noaa()
   } else {
     plt2 <- plt
-    # Check if length of ref_line = dat
-    # replicate value if not
-    if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
-    # Put into for loop and add lines sequentially to plt
-    for (i in 1:length(ref_line)) {
-      # find the reference point value
-      if (is.null(names(ref_line[i]))) {
-        ref_line_x <- calculate_reference_point(
-          dat = dat[[i]],
-          reference_name = glue::glue("fishing_mortality_{ref_line[i]}"),
-          lbs = lbs
-        ) / scale_amount
-        ref_line_x <- setNames(ref_line_x, ref_line[i])
-      } else {
-        ref_line_x <- ref_line[i] / scale_amount
-      }
-      
-      if ("unfished" %in% names(ref_line_x)) {
-        # find the minimum x axis value from the plot
-        min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
-          as.data.frame() |>
-          dplyr::pull(x) |>
-          min() |>
-          round(digits = 2)
-        # add point to plot and add theme
-        plt2 <- plt2 +
-          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-          theme_noaa()
-      } else {
-        # add apply/purrr/or for loop for reference lines -- not just the first anymore
-        plt2 <- plt2 +
-          reference_line(
-            # conditionally add label name
-            label_name = ifelse(length(names(ref_line)) == 1, "fishing_mortality", names(dat)[i]), #"spawning_biomass",
-            ref_line = ref_line_x,
-            scale_amount = 1
-          )
+    if (is.null(names(ref_line[i]))) {
+      # Check if length of ref_line = dat
+      # replicate value if not
+      if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
+      # Put into for loop and add lines sequentially to plt
+      for (i in 1:length(ref_line)) {
+        # find the reference point value
+        if (is.null(names(ref_line[i]))) {
+          ref_line_x <- calculate_reference_point(
+            dat = dat[[i]],
+            reference_name = glue::glue("fishing_mortality_{ref_line[i]}"),
+            lbs = lbs
+          ) / scale_amount
+          ref_line_x <- setNames(ref_line_x, ref_line[i])
+        } else {
+          ref_line_x <- ref_line[i] / scale_amount
+        }
+        
+        if ("unfished" %in% names(ref_line_x)) {
+          # find the minimum x axis value from the plot
+          min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
+            as.data.frame() |>
+            dplyr::pull(x) |>
+            min() |>
+            round(digits = 2)
+          # add point to plot and add theme
+          plt2 <- plt2 +
+            ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
+            theme_noaa()
+        } else {
+          # add apply/purrr/or for loop for reference lines -- not just the first anymore
+          plt2 <- plt2 +
+            reference_line(
+              # conditionally add label name
+              label_name = ifelse(length(names(ref_line)) == 1, "fishing_mortality", names(dat)[i]), #"spawning_biomass",
+              ref_line = ref_line_x,
+              scale_amount = 1
+            )
+        }
       }
     }
     final <- plt2 + theme_noaa()

--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -86,49 +86,15 @@ plot_fishing_mortality <- function(
     # don't add any reference line here and just add theme for final plot
     final <- plt + theme_noaa()
   } else {
-    plt2 <- plt
-    if (is.null(names(ref_line[i]))) {
-      # Check if length of ref_line = dat
-      # replicate value if not
-      if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
-      # Put into for loop and add lines sequentially to plt
-      for (i in 1:length(ref_line)) {
-        # find the reference point value
-        if (is.null(names(ref_line[i]))) {
-          ref_line_x <- calculate_reference_point(
-            dat = dat[[i]],
-            reference_name = glue::glue("fishing_mortality_{ref_line[i]}"),
-            lbs = lbs
-          ) / scale_amount
-          ref_line_x <- setNames(ref_line_x, ref_line[i])
-        } else {
-          ref_line_x <- ref_line[i] / scale_amount
-        }
-        
-        if ("unfished" %in% names(ref_line_x)) {
-          # find the minimum x axis value from the plot
-          min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
-            as.data.frame() |>
-            dplyr::pull(x) |>
-            min() |>
-            round(digits = 2)
-          # add point to plot and add theme
-          plt2 <- plt2 +
-            ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-            theme_noaa()
-        } else {
-          # add apply/purrr/or for loop for reference lines -- not just the first anymore
-          plt2 <- plt2 +
-            reference_line(
-              # conditionally add label name
-              label_name = ifelse(length(names(ref_line)) == 1, "fishing_mortality", names(dat)[i]), #"spawning_biomass",
-              ref_line = ref_line_x,
-              scale_amount = 1
-            )
-        }
-      }
-    }
-    final <- plt2 + theme_noaa()
+    final <- plt +
+      add_reference_line(
+        dat = dat, 
+        ref_line = ref_line, 
+        label = "fishing_mortality", 
+        lbs = lbs,
+        scale_amount = scale_amount
+      ) +
+      theme_noaa()
   }
 
   ### Make RDA ----

--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -84,6 +84,10 @@ plot_fishing_mortality <- function(
         label = "fishing_mortality"
       ) +
       theme_noaa()
+  
+  if (!is.data.frame(dat)) {
+    final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+  }
 
   ### Make RDA ----
   if (make_rda) {

--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -82,20 +82,13 @@ plot_fishing_mortality <- function(
   # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
   # 3. input vector of labels = c("msy", "target")
   # getting data set - an ifelse statement in the fxn wasn't working
-  if (relative) {
-    # don't add any reference line here and just add theme for final plot
-    final <- plt + theme_noaa()
-  } else {
-    final <- plt +
+  final <- plt +
       add_reference_line(
         dat = dat, 
         ref_line = ref_line, 
-        label = "fishing_mortality", 
-        lbs = lbs,
-        scale_amount = scale_amount
+        label = "fishing_mortality"
       ) +
       theme_noaa()
-  }
 
   ### Make RDA ----
   if (make_rda) {

--- a/R/plot_fishing_mortality.R
+++ b/R/plot_fishing_mortality.R
@@ -77,11 +77,6 @@ plot_fishing_mortality <- function(
     ...
   )
   # Add reference line
-  # Conditions for ref line
-  # 1. all are comparing same value = msy, target, unfished...
-  # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
-  # 3. input vector of labels = c("msy", "target")
-  # getting data set - an ifelse statement in the fxn wasn't working
   final <- plt +
       add_reference_line(
         dat = dat, 

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -245,19 +245,11 @@ plot_spawning_biomass <- function(
         # add apply/purrr/or for loop for reference lines -- not just the first anymore
         plt2 <- plt2 +
           reference_line(
-            label_name = names(dat)[i], #"spawning_biomass",
+            # conditionally add label name
+            label_name = ifelse(length(names(ref_line)) == 1, "spawning_biomass", names(dat)[i]), #"spawning_biomass",
             ref_line = ref_line_x,
             scale_amount = 1
           )
-          
-        #   reference_line(
-        #   plot = plt,
-        #   dat = rp_dat,
-        #   lbs = lbs,
-        #   label_name = "spawning_biomass",
-        #   reference = ref_line,
-        #   scale_amount = scale_amount
-        # ) + theme_noaa()
       }
     }
     final <- plt2 + theme_noaa()

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -145,12 +145,6 @@ plot_spawning_biomass <- function(
       )
     }
   )
-  # Pull first df if in a list to find reference point
-  # if (!is.data.frame(dat)) {
-  #   rp_dat <- dat[[1]]
-  # } else {
-  #   rp_dat <- dat
-  # }
 
   if (relative & scale_amount > 1) {
     cli::cli_alert_warning("Scale amount is not applicable when relative = TRUE. Resetting scale_amount to 1.")
@@ -216,23 +210,26 @@ plot_spawning_biomass <- function(
     final <- plt + theme_noaa()
   } else {
     plt2 <- plt
+    # Check if length of ref_line = dat
+    # replicate value if not
+    if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
     # Put into for loop and add lines sequentially to plt
     for (i in 1:length(ref_line)) {
       # find the reference point value
       if (is.null(names(ref_line[i]))) {
         ref_line_x <- calculate_reference_point(
           dat = dat[[i]],
-          reference_name = i,
+          reference_name = glue::glue("spawning_biomass_{ref_line[i]}"),
           lbs = lbs
         ) / scale_amount
-        ref_line_x <- setNames(ref_line_x, i)
+        ref_line_x <- setNames(ref_line_x, ref_line[i])
       } else {
         ref_line_x <- ref_line[i] / scale_amount
       }
       
         if ("unfished" %in% names(ref_line_x)) {
         # find the minimum x axis value from the plot
-        min_year <- min <- ggplot2::ggplot_build(plt)[["data"]][[2]] |> # I think this was causing issues on linux
+        min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
           as.data.frame() |>
           dplyr::pull(x) |>
           min() |>

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -146,11 +146,11 @@ plot_spawning_biomass <- function(
     }
   )
   # Pull first df if in a list to find reference point
-  if (!is.data.frame(dat)) {
-    rp_dat <- dat[[1]]
-  } else {
-    rp_dat <- dat
-  }
+  # if (!is.data.frame(dat)) {
+  #   rp_dat <- dat[[1]]
+  # } else {
+  #   rp_dat <- dat
+  # }
 
   if (relative & scale_amount > 1) {
     cli::cli_alert_warning("Scale amount is not applicable when relative = TRUE. Resetting scale_amount to 1.")
@@ -206,38 +206,61 @@ plot_spawning_biomass <- function(
     ...
   )
   # Add reference line
+  # Conditions for ref line
+  # 1. all are comparing same value = msy, target, unfished...
+  # 2. custom input vector = c("sabe23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+  # 3. input vector of labels = c("msy", "target")
   # getting data set - an ifelse statement in the fxn wasn't working
   if (relative) {
     # don't add any reference line here and just add theme for final plot
     final <- plt + theme_noaa()
   } else {
-    if ("unfished" %in% c(names(ref_line), ref_line)) {
-      # find the minimum x axis value from the plot
-      min_year <- min <- ggplot2::ggplot_build(plt)[["data"]][[2]] |>
-        as.data.frame() |>
-        dplyr::pull(x) |>
-        min() |>
-        round(digits = 2)
-      # find the reference point value for unfished
-      ref_point <- calculate_reference_point(
-        dat = rp_dat,
-        reference_name = "spawing_biomass_unfished"
-      ) / scale_amount
-      # add point to plot and add theme
-      final <- plt +
-        ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-        theme_noaa()
-    } else {
-      # add apply/purrr/or for loop for reference lines -- not just the first anymore
-      final <- reference_line(
-        plot = plt,
-        dat = rp_dat,
-        lbs = lbs,
-        label_name = "spawning_biomass",
-        reference = ref_line,
-        scale_amount = scale_amount
-      ) + theme_noaa()
+    plt2 <- plt
+    # Put into for loop and add lines sequentially to plt
+    for (i in 1:length(ref_line)) {
+      # find the reference point value
+      if (is.null(names(ref_line[i]))) {
+        ref_line_x <- calculate_reference_point(
+          dat = dat[[i]],
+          reference_name = i,
+          lbs = lbs
+        ) / scale_amount
+        ref_line_x <- setNames(ref_line_x, i)
+      } else {
+        ref_line_x <- ref_line[i] / scale_amount
+      }
+      
+        if ("unfished" %in% names(ref_line_x)) {
+        # find the minimum x axis value from the plot
+        min_year <- min <- ggplot2::ggplot_build(plt)[["data"]][[2]] |> # I think this was causing issues on linux
+          as.data.frame() |>
+          dplyr::pull(x) |>
+          min() |>
+          round(digits = 2)
+        # add point to plot and add theme
+        plt2 <- plt2 +
+          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
+          theme_noaa()
+      } else {
+        # add apply/purrr/or for loop for reference lines -- not just the first anymore
+        plt2 <- plt2 +
+          reference_line(
+            label_name = names(dat)[i], #"spawning_biomass",
+            ref_line = ref_line_x,
+            scale_amount = 1
+          )
+          
+        #   reference_line(
+        #   plot = plt,
+        #   dat = rp_dat,
+        #   lbs = lbs,
+        #   label_name = "spawning_biomass",
+        #   reference = ref_line,
+        #   scale_amount = scale_amount
+        # ) + theme_noaa()
+      }
     }
+    final <- plt2 + theme_noaa()
   }
 
   ### Make RDA ----

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -202,7 +202,7 @@ plot_spawning_biomass <- function(
   # Add reference line
   # Conditions for ref line
   # 1. all are comparing same value = msy, target, unfished...
-  # 2. custom input vector = c("sabe23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+  # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
   # 3. input vector of labels = c("msy", "target")
   # getting data set - an ifelse statement in the fxn wasn't working
   if (relative) {

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -32,7 +32,7 @@
 #' custom). When multiple models are being compared, a reference line for each 
 #' model will appear, if desired. The following options can be used to customize 
 #' the reference line:
-#' 1. all lines are comparing same ref_line = "msy", ref_line = "target", ref_line = "unfished", ect
+#' 1. all lines are comparing same ref_line = "msy", ref_line = "target", ref_line = "unfished", etc
 #' 2. custom input vector - ref_line = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
 #' 3. input vector of labels - ref_line = c("msy", "target")
 #'

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -28,9 +28,15 @@
 #' Default: "time"
 #'
 #' Options: "early", "time", "fore" (forecast), or NULL (all data)
-#' @param ref_line String. Reference point name.
+#' @param ref_line String or named vector. Reference point name (and value if 
+#' custom). When multiple models are being compared, a reference line for each 
+#' model will appear, if desired. The following options can be used to customize 
+#' the reference line:
+#' 1. all lines are comparing same ref_line = "msy", ref_line = "target", ref_line = "unfished", ect
+#' 2. custom input vector - ref_line = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+#' 3. input vector of labels - ref_line = c("msy", "target")
 #'
-#' Default: "target"
+#' Default: "msy"
 #'
 #' Options: (including, but not limited to) "target", "msy", and "unfished"
 #' If the reference point is not found in the data, set ref_line = c("name" = value).
@@ -103,6 +109,12 @@
 #'   interactive = FALSE,
 #'   module = "TIME_SERIES"
 #' )
+#' \dontrun{
+#' plot_spawning_biomass(
+#'   dat = list("2023" = model1, "2025" = model2),
+#'   ref_line = c("SBF30"=1500,"SBF40"=2300)
+#' )
+#' }
 plot_spawning_biomass <- function(
   dat,
   geom = "line",

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -196,8 +196,8 @@ plot_spawning_biomass <- function(
     ylab = spawning_biomass_label,
     group = group,
     # add check in case facet is returned as character(0)
-    facet = if (length(facet) > 0) facet else NULL#,
-    # ...
+    facet = if (length(facet) > 0) facet else NULL,
+    ...
   )
   # Add reference line
   if (relative) {

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -226,6 +226,10 @@ plot_spawning_biomass <- function(
       ) + 
       theme_noaa()
   }
+  
+  if (!is.data.frame(dat)) {
+    final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+  }
 
   ### Make RDA ----
   if (make_rda) {

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -228,7 +228,17 @@ plot_spawning_biomass <- function(
   }
   
   if (!is.data.frame(dat)) {
-    final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+    if (!is.null(names(ref_line))) {
+      if (any(
+        grepl(
+          glue::glue("^spawning_biomass_{ref_line}"), # ifelse(is.null(names(ref_line)), x, names(ref_line))
+          # TODO: make this check more efficient
+          ifelse(is.data.frame(dat), dat[["label"]], sapply(dat, `[[`, "label"))
+        )
+      )) {
+        final <- final + ggplot2::scale_color_discrete(breaks = names(dat))
+      }
+    }
   }
 
   ### Make RDA ----

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -196,8 +196,8 @@ plot_spawning_biomass <- function(
     ylab = spawning_biomass_label,
     group = group,
     # add check in case facet is returned as character(0)
-    facet = if (length(facet) > 0) facet else NULL,
-    ...
+    facet = if (length(facet) > 0) facet else NULL#,
+    # ...
   )
   # Add reference line
   # Conditions for ref line
@@ -209,47 +209,15 @@ plot_spawning_biomass <- function(
     # don't add any reference line here and just add theme for final plot
     final <- plt + theme_noaa()
   } else {
-    plt2 <- plt
-    # Check if length of ref_line = dat
-    # replicate value if not
-    if (length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
-    # Put into for loop and add lines sequentially to plt
-    for (i in 1:length(ref_line)) {
-      # find the reference point value
-      if (is.null(names(ref_line[i]))) {
-        ref_line_x <- calculate_reference_point(
-          dat = dat[[i]],
-          reference_name = glue::glue("spawning_biomass_{ref_line[i]}"),
-          lbs = lbs
-        ) / scale_amount
-        ref_line_x <- setNames(ref_line_x, ref_line[i])
-      } else {
-        ref_line_x <- ref_line[i] / scale_amount
-      }
-      
-        if ("unfished" %in% names(ref_line_x)) {
-        # find the minimum x axis value from the plot
-        min_year <- min <- ggplot2::ggplot_build(plt2)[["data"]][[2]] |> # I think this was causing issues on linux?
-          as.data.frame() |>
-          dplyr::pull(x) |>
-          min() |>
-          round(digits = 2)
-        # add point to plot and add theme
-        plt2 <- plt2 +
-          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-          theme_noaa()
-      } else {
-        # add apply/purrr/or for loop for reference lines -- not just the first anymore
-        plt2 <- plt2 +
-          reference_line(
-            # conditionally add label name
-            label_name = ifelse(length(names(ref_line)) == 1, "spawning_biomass", names(dat)[i]), #"spawning_biomass",
-            ref_line = ref_line_x,
-            scale_amount = 1
-          )
-      }
-    }
-    final <- plt2 + theme_noaa()
+    final <- plt + 
+      add_reference_line(
+        dat = dat, 
+        ref_line = ref_line, 
+        label = "spawning_biomass", 
+        lbs = lbs,
+        scale_amount = scale_amount
+      ) + 
+      theme_noaa()
   }
 
   ### Make RDA ----

--- a/R/plot_spawning_biomass.R
+++ b/R/plot_spawning_biomass.R
@@ -200,11 +200,6 @@ plot_spawning_biomass <- function(
     # ...
   )
   # Add reference line
-  # Conditions for ref line
-  # 1. all are comparing same value = msy, target, unfished...
-  # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
-  # 3. input vector of labels = c("msy", "target")
-  # getting data set - an ifelse statement in the fxn wasn't working
   if (relative) {
     # don't add any reference line here and just add theme for final plot
     final <- plt + theme_noaa()

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -1145,7 +1145,7 @@ add_reference_line <- function(
           cli::cli_alert_warning("{label}_{ref_line[i]} not found for {ifelse(is.data.frame(dat), 'data', names(dat[i]))}")
           next
         }
-        ref_line_x <- setNames(ref_line_x, ref_line[i])
+        ref_line_x <- utils::setNames(ref_line_x, ref_line[i])
       } else {
         ref_line_x <- ref_line[i] / scale_amount
       }

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -534,6 +534,7 @@ cohort_line <- function(
 #' @param label_name String. Name of the quantity that users want to
 #' extract the reference point from
 #' @param ref_line String. Reference point(s)
+#' @param model_name String. Name of the model that will be present in the legend.
 #'
 #' Options: Including, but not limited to: "msy", "unfished", "target"
 #'

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -71,34 +71,19 @@ plot_timeseries <- function(
 ) {
   # Start plot
   plot <- ggplot2::ggplot()
-  # make into new geom?
-  # more defaults and fxnality for ggplot
 
   # Add geom
   plot <- switch(geom,
     "point" = {
-      # point_size = ifelse(
-      #   is.null(list(...)$size),
-      #   2.0,
-      #   list(...)$size
-      # )
       plot +
         ggplot2::geom_point(
           data = dat,
           ggplot2::aes(
             .data[[x]],
             .data[[y]],
-            # TODO: add more groupings
-            # shape = ifelse(any(grepl("shape", names(group))), .data[[group[[grep("shape", names(group))]]]], 1),
-            # color = ifelse(any(grepl("color", names(group))), .data[[group[[grep("color", names(group))]]]], "black")
-            color = if (length(unique(.data[["model"]])) > 1) {
-              interaction(model, group_var)
-            } else {
-              group_var
-            },
+            color = model,
             shape = group_var
           ),
-          # size = point_size,
           ...
         )
     },
@@ -123,7 +108,8 @@ plot_timeseries <- function(
               }
             }
           ),
-          alpha = 0.3
+          alpha = 0.3,
+          show.legend = ifelse(all(is.na(dat$estimate_lower)), FALSE, TRUE)
         ) +
         # }
         ggplot2::geom_line(
@@ -131,8 +117,6 @@ plot_timeseries <- function(
           ggplot2::aes(
             x = .data[[x]],
             y = .data[[y]],
-            # linetype = group_var,
-            # linetype = ifelse(!is.null(group), group_var, "solid"),
             color = {
               if (length(unique(.data[["model"]])) > 1) {
                 interaction(model, group_var)
@@ -141,7 +125,7 @@ plot_timeseries <- function(
               }
             }
           ),
-          # linewidth = 1.0,
+          show.legend = FALSE, #ifelse(all(is.na(dat$estimate_lower)), TRUE, FALSE),
           ...
         )
     },
@@ -152,11 +136,7 @@ plot_timeseries <- function(
           ggplot2::aes(
             x = .data[[x]],
             y = .data[[y]],
-            fill = if (length(unique(.data[["model"]])) > 1) {
-              interaction(model, group_var)
-            } else {
-              group_var
-            }
+            fill = interaction(model, group_var) # model
           ),
           position = "identity",
           alpha = 0.5,
@@ -205,15 +185,7 @@ plot_timeseries <- function(
       # return plot if option beyond line and point for now
       labs
     )
-  } # else if (length(unique(dat$model)) == 1) {
-  #   labs <- switch(geom,
-  #     "line" = labs + ggplot2::guides(color = "none"),
-  #     "point" = labs + ggplot2::guides(color = "none"),
-  #     "area" = labs + ggplot2::guides(fill = "none"),
-  #     # return plot if option beyond line and point for now
-  #     labs
-  #   )
-  # }
+  }
 
   # Calc axis breaks
   x_n_breaks <- axis_breaks(dat[[x]])
@@ -576,7 +548,8 @@ cohort_line <- function(
 reference_line <- function(
   label_name,
   ref_line,
-  scale_amount = 1
+  scale_amount = 1,
+  model_name = "1"
 ) {
   # Extract reference line values and labels
   ref_line_val <- ref_line[[1]]
@@ -585,21 +558,25 @@ reference_line <- function(
   list(
     # Add geom for ref line
     ggplot2::geom_hline(
-      yintercept = ref_line_val / scale_amount,
-      color = "black",
-      linetype = "dashed"
+      data = data.frame(yintercept = ref_line_val, model = model_name, group_var = "1"),
+      ggplot2::aes(
+        yintercept = ref_line_val / scale_amount,
+        color = interaction(model, group_var) # model
+      ),
+      linetype = "dashed",
+      show.legend = FALSE
     ),
     # add line annotation
     ggplot2::annotate(
       geom = "text",
       # TODO: need to change this for general process
-      x = Inf,
+      x = -Inf,
       y = ref_line_val / scale_amount,
-      label = glue::glue("{stringr::str_replace_all(label_name, '_', '~')}[{reference}]"), # list(bquote(label_name[.(reference)])),
+      label = glue::glue("{reference}"), # glue::glue("{stringr::str_replace_all(label_name, '_', '~')}[{reference}]"), # list(bquote(label_name[.(reference)])),
       parse = TRUE,
-      hjust = 1.05, # slight offset so text doesn't hit border
-      vjust = -0.5, #slightly above line
-      size = 5 # this is not foolproof
+      hjust = -0.05, # slight offset so text doesn't hit border
+      vjust = -0.5 # , #slightly above line
+      # size = 5 # this is not foolproof
     )
   )
 }
@@ -1145,7 +1122,7 @@ add_reference_line <- function(
           cli::cli_alert_warning("{label}_{ref_line[i]} not found for {ifelse(is.data.frame(dat), 'data', names(dat[i]))}")
           next
         }
-        ref_line_x <- utils::setNames(ref_line_x, ref_line[i])
+        ref_line_x <- stats::setNames(ref_line_x, ref_line[i])
       } else {
         ref_line_x <- ref_line[i] / scale_amount
       }
@@ -1167,7 +1144,7 @@ add_reference_line <- function(
         # plt2 <- plt2 +
         # TODO: set color for each point to match that of the line for the model
         ref_lines_list <- append(ref_lines_list,
-          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_line_x)) # should I keep -1 or set as first year?
+          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_line_x, color = model)) # should I keep -1 or set as first year?
         )
       } else {
         # add apply/purrr/or for loop for reference lines -- not just the first anymore
@@ -1177,7 +1154,8 @@ add_reference_line <- function(
             # conditionally add label name
             label_name = ifelse(length(names(dat)[i]) == 1, label, names(dat)[i]), #"spawning_biomass",
             ref_line = ref_line_x,
-            scale_amount = scale_amount
+            scale_amount = scale_amount,
+            model_name = ifelse(is.data.frame(dat), "1", names(dat)[i])
           )
         )
       }

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -559,11 +559,9 @@ cohort_line <- function(
 #' Preformatted reference line
 #'
 #' @inheritParams plot_spawning_biomass
-#' @param plot Plot object. A ggplot2 object where the reference line will be added
-#' @param dat Data frame. Standard data frame where reference point should be extracted
 #' @param label_name String. Name of the quantity that users want to
 #' extract the reference point from
-#' @param reference String of the reference point
+#' @param ref_line String of the reference point
 #'
 #' Options: Including, but not limited to: "msy", "unfished", "target"
 #'
@@ -576,48 +574,34 @@ cohort_line <- function(
 #' reference_line(dat, "biomass", "msy")
 #' }
 reference_line <- function(
-  plot,
-  dat,
   label_name,
-  reference,
-  scale_amount = 1,
-  lbs = FALSE
+  ref_line,
+  scale_amount = 1
 ) {
-  if (!is.null(names(reference))) {
-    ref_line_val <- reference[[1]]
-    reference <- names(reference)
-  } else {
-    # calculate reference point value
-    ref_line_val <- calculate_reference_point(
-      dat = dat,
-      reference_name = glue::glue("{label_name}_{reference}"),
-      lbs = lbs
-    )
-  }
+  # Extract reference line values and labels
+  ref_line_val <- ref_line[[1]]
+  reference <- names(ref_line)
 
-  # Add geom for ref line
-  if (is.null(ref_line_val)) {
-    plot
-  } else {
-    plot +
-      ggplot2::geom_hline(
-        # ggplot2::aes(
-        yintercept = ref_line_val / scale_amount,
-        # ),
-        color = "black",
-        linetype = "dashed"
-      ) +
-      ggplot2::annotate(
-        geom = "text",
-        x = as.numeric(max(dat$year[dat$era == "time"], na.rm = TRUE)),
-        y = ref_line_val / scale_amount,
-        label = glue::glue("{stringr::str_replace_all(label_name, '_', '~')}[{reference}]"), # list(bquote(label_name[.(reference)])),
-        parse = TRUE,
-        hjust = 1,
-        vjust = 0,
-        size = 5 # this is not foolproof
-      )
-  }
+  list(
+    # Add geom for ref line
+    ggplot2::geom_hline(
+      yintercept = ref_line_val / scale_amount,
+      color = "black",
+      linetype = "dashed"
+    ),
+    # add line annotation
+    ggplot2::annotate(
+      geom = "text",
+      # TODO: need to change this for general process
+      x = Inf,
+      y = ref_line_val / scale_amount,
+      label = glue::glue("{stringr::str_replace_all(label_name, '_', '~')}[{reference}]"), # list(bquote(label_name[.(reference)])),
+      parse = TRUE,
+      hjust = 1.05, # slight offset so text doesn't hit border
+      vjust = -0.5, #slightly above line
+      size = 5 # this is not foolproof
+    )
+  )
 }
 
 #------------------------------------------------------------------------------

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -1122,6 +1122,12 @@ add_reference_line <- function(
     lbs = FALSE,
     scale_amount = 1
 ) {
+  # Add reference line
+  # Conditions for ref line
+  # 1. all are comparing same value = msy, target, unfished...
+  # 2. custom input vector = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+  # 3. input vector of labels = c("msy", "target")
+  # getting data set - an ifelse statement in the fxn wasn't working
   ref_lines_list <- list()
   if (!is.null(ref_line)) {
     # Check if length of ref_line = dat

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -1165,6 +1165,7 @@ add_reference_line <- function(
           round(digits = 2)
         # add point to plot and add theme
         # plt2 <- plt2 +
+        # TODO: set color for each point to match that of the line for the model
         ref_lines_list <- append(ref_lines_list,
           ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_line_x)) # should I keep -1 or set as first year?
         )

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -533,7 +533,7 @@ cohort_line <- function(
 #' @inheritParams plot_spawning_biomass
 #' @param label_name String. Name of the quantity that users want to
 #' extract the reference point from
-#' @param ref_line String of the reference point
+#' @param ref_line String. Reference point(s)
 #'
 #' Options: Including, but not limited to: "msy", "unfished", "target"
 #'

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -108,8 +108,8 @@ plot_timeseries <- function(
               }
             }
           ),
-          alpha = 0.3,
-          show.legend = ifelse(all(is.na(dat$estimate_lower)), FALSE, TRUE)
+          alpha = 0.3 #,
+          # show.legend = ifelse(all(is.na(dat$estimate_lower)), FALSE, TRUE)
         ) +
         # }
         ggplot2::geom_line(
@@ -125,7 +125,7 @@ plot_timeseries <- function(
               }
             }
           ),
-          show.legend = FALSE, #ifelse(all(is.na(dat$estimate_lower)), TRUE, FALSE),
+          # show.legend = FALSE, #ifelse(all(is.na(dat$estimate_lower)), TRUE, FALSE),
           ...
         )
     },

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -1119,7 +1119,7 @@ add_reference_line <- function(
           reference_name = glue::glue("{label}_{ref_line[i]}"),
           lbs = lbs
         ) / scale_amount
-        if (length(ref_line_x) == 0) {
+        if (length(ref_line_x) == 0 || is.na(ref_line_x)) {
           cli::cli_alert_warning("{label}_{ref_line[i]} not found for {ifelse(is.data.frame(dat), 'data', names(dat[i]))}")
           next
         }

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -1112,3 +1112,61 @@ plot_obsvpred <- function(
   }
   final
 }
+
+#------------------------------------------------------------------------------
+
+add_reference_line <- function(
+    dat,
+    ref_line,
+    label,
+    lbs = FALSE,
+    scale_amount = 1
+) {
+  ref_lines_list <- list()
+  if (!is.null(ref_line)) {
+    # Check if length of ref_line = dat
+    # replicate value if not
+    if (!is.data.frame(dat) & length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
+    # Put into for loop and add lines sequentially to plt
+    for (i in 1:length(ref_line)) {
+      # find the reference point value
+      if (is.null(names(ref_line[i]))) {
+        ref_line_x <- calculate_reference_point(
+          dat = if (is.data.frame(dat)) { dat } else { dat[[i]] },
+          reference_name = glue::glue("{label}_{ref_line[i]}"),
+          lbs = lbs
+        ) / scale_amount
+        ref_line_x <- setNames(ref_line_x, ref_line[i])
+      } else {
+        ref_line_x <- ref_line[i] / scale_amount
+      }
+      
+      if ("unfished" %in% names(ref_line_x)) {
+        # find the minimum x axis value from the plot
+        min_year <- dat |> 
+          dplyr::filter(grepl(label, label)) |>
+          dplyr::pull(estimate) |>
+          min() |>
+          round(digits = 2)
+        # add point to plot and add theme
+        # plt2 <- plt2 +
+        ref_lines_list <- append(ref_lines_list,
+          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
+            theme_noaa()
+        )
+      } else {
+        # add apply/purrr/or for loop for reference lines -- not just the first anymore
+        # plt2 <- plt2 +
+        ref_lines_list <- append(ref_lines_list,
+          reference_line(
+            # conditionally add label name
+            label_name = ifelse(length(names(dat)[i]) == 1, "spawning_biomass", names(dat)[i]), #"spawning_biomass",
+            ref_line = ref_line_x,
+            scale_amount = scale_amount
+          )
+        )
+      }
+    } # close ref_line for loop
+  } # close if ref_line NULL
+  ref_lines_list
+}

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -1130,8 +1130,7 @@ add_reference_line <- function(
   # getting data set - an ifelse statement in the fxn wasn't working
   ref_lines_list <- list()
   if (!is.null(ref_line)) {
-    # Check if length of ref_line = dat
-    # replicate value if not
+    # Check if length of ref_line = dat -- replicate value if not
     if (!is.data.frame(dat) & length(ref_line) != length(dat)) ref_line <- rep(ref_line, length(dat))
     # Put into for loop and add lines sequentially to plt
     for (i in 1:length(ref_line)) {
@@ -1142,23 +1141,32 @@ add_reference_line <- function(
           reference_name = glue::glue("{label}_{ref_line[i]}"),
           lbs = lbs
         ) / scale_amount
+        if (length(ref_line_x) == 0) {
+          cli::cli_alert_warning("{label}_{ref_line[i]} not found for {ifelse(is.data.frame(dat), 'data', names(dat[i]))}")
+          next
+        }
         ref_line_x <- setNames(ref_line_x, ref_line[i])
       } else {
         ref_line_x <- ref_line[i] / scale_amount
       }
       
       if ("unfished" %in% names(ref_line_x)) {
+        if (is.data.frame(dat)) {
+          sel_dat <- dat
+        } else {
+          sel_dat <- dat[[i]]
+        }
+        plt_lab <- label
         # find the minimum x axis value from the plot
-        min_year <- dat |> 
-          dplyr::filter(grepl(label, label)) |>
-          dplyr::pull(estimate) |>
-          min() |>
+        min_year <- sel_dat |> 
+          dplyr::filter(grepl(plt_lab, label), year != 1) |>
+          dplyr::pull(year) |>
+          min(na.rm = TRUE) |>
           round(digits = 2)
         # add point to plot and add theme
         # plt2 <- plt2 +
         ref_lines_list <- append(ref_lines_list,
-          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_point)) + # should I keep -1 or set as first year?
-            theme_noaa()
+          ggplot2::geom_point(ggplot2::aes(x = min_year - 1, y = ref_line_x)) # should I keep -1 or set as first year?
         )
       } else {
         # add apply/purrr/or for loop for reference lines -- not just the first anymore
@@ -1166,7 +1174,7 @@ add_reference_line <- function(
         ref_lines_list <- append(ref_lines_list,
           reference_line(
             # conditionally add label name
-            label_name = ifelse(length(names(dat)[i]) == 1, "spawning_biomass", names(dat)[i]), #"spawning_biomass",
+            label_name = ifelse(length(names(dat)[i]) == 1, label, names(dat)[i]), #"spawning_biomass",
             ref_line = ref_line_x,
             scale_amount = scale_amount
           )

--- a/R/utils_rda.R
+++ b/R/utils_rda.R
@@ -177,7 +177,7 @@ calc_kqs <- function(returned_kq,
   if (returned_kq == "F.min") {
     return(
       prepared_data$estimate |>
-        na.omit() |>
+        data.table::na.omit() |>
         min() |>
         round(digits = 3)
     )
@@ -186,7 +186,7 @@ calc_kqs <- function(returned_kq,
   if (returned_kq == "F.max") {
     return(
       prepared_data$estimate |>
-        na.omit() |>
+        data.table::na.omit() |>
         max() |>
         round(digits = 3)
     )

--- a/R/utils_rda.R
+++ b/R/utils_rda.R
@@ -177,7 +177,7 @@ calc_kqs <- function(returned_kq,
   if (returned_kq == "F.min") {
     return(
       prepared_data$estimate |>
-        data.table::na.omit() |>
+        stats::na.omit() |>
         min() |>
         round(digits = 3)
     )
@@ -186,7 +186,7 @@ calc_kqs <- function(returned_kq,
   if (returned_kq == "F.max") {
     return(
       prepared_data$estimate |>
-        data.table::na.omit() |>
+        stats::na.omit() |>
         max() |>
         round(digits = 3)
     )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,4 +1,5 @@
 BAM
+Birthseason
 CPUE
 FIMS
 FIMSdiags
@@ -13,12 +14,12 @@ Preformatted
 Rda
 Rmarkdown
 Rmd
+Subseason
 aa
 alttext
 asar
 bam
 birthseas
-birthseason
 cha
 cmd
 conjuction
@@ -29,6 +30,7 @@ dat
 dataframe's
 diagonostic
 dplyr
+ect
 facetting
 fims
 flextable

--- a/man/plot_fishing_mortality.Rd
+++ b/man/plot_fishing_mortality.Rd
@@ -42,9 +42,15 @@ Options: Including, but not limited to: "year", "area", "fleet", "sex", "none", 
 
 Default: NULL}
 
-\item{ref_line}{String. Reference point name.
+\item{ref_line}{String or named vector. Reference point name (and value if 
+custom). When multiple models are being compared, a reference line for each 
+model will appear, if desired. The following options can be used to customize 
+the reference line:
+1. all lines are comparing same ref_line = "msy", ref_line = "target", ref_line = "unfished", ect
+2. custom input vector - ref_line = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+3. input vector of labels - ref_line = c("msy", "target")
 
-Default: "target"
+Default: "msy"
 
 Options: (including, but not limited to) "target", "msy", and "unfished"
 If the reference point is not found in the data, set ref_line = c("name" = value).}

--- a/man/plot_spawning_biomass.Rd
+++ b/man/plot_spawning_biomass.Rd
@@ -46,9 +46,15 @@ Options: Including, but not limited to: "year", "area", "fleet", "sex", "none", 
 
 Default: NULL}
 
-\item{ref_line}{String. Reference point name.
+\item{ref_line}{String or named vector. Reference point name (and value if 
+custom). When multiple models are being compared, a reference line for each 
+model will appear, if desired. The following options can be used to customize 
+the reference line:
+1. all lines are comparing same ref_line = "msy", ref_line = "target", ref_line = "unfished", ect
+2. custom input vector - ref_line = c("sable23_msy"=30, "sable25_msy"=40) -- user must indicate which model in label otherwise it will assign in order of dat
+3. input vector of labels - ref_line = c("msy", "target")
 
-Default: "target"
+Default: "msy"
 
 Options: (including, but not limited to) "target", "msy", and "unfished"
 If the reference point is not found in the data, set ref_line = c("name" = value).}
@@ -138,6 +144,12 @@ plot_spawning_biomass(
   interactive = FALSE,
   module = "TIME_SERIES"
 )
+\dontrun{
+plot_spawning_biomass(
+  dat = list("2023" = model1, "2025" = model2),
+  ref_line = c("SBF30"=1500,"SBF40"=2300)
+)
+}
 }
 \seealso{
 [convert_output()], [plot_timeseries()], [calculate_reference_point()], [reference_line()], [filter_data()], [process_data()], [export_kqs()], [insert_kqs()], [create_rda()]

--- a/man/reference_line.Rd
+++ b/man/reference_line.Rd
@@ -4,29 +4,19 @@
 \alias{reference_line}
 \title{Preformatted reference line}
 \usage{
-reference_line(plot, dat, label_name, reference, scale_amount = 1, lbs = FALSE)
+reference_line(label_name, ref_line, scale_amount = 1)
 }
 \arguments{
-\item{plot}{Plot object. A ggplot2 object where the reference line will be added}
-
-\item{dat}{Data frame. Standard data frame where reference point should be extracted}
-
 \item{label_name}{String. Name of the quantity that users want to
 extract the reference point from}
 
-\item{reference}{String of the reference point
+\item{ref_line}{String of the reference point
 
 Options: Including, but not limited to: "msy", "unfished", "target"}
 
 \item{scale_amount}{Number. A number to scale the y-axis values.
 
 Default: 1}
-
-\item{lbs}{Logical. TRUE/FALSE; indicate whether to convert the y-axis values from
-kilograms to pounds. The default units match the default in the
-unit_label argument - 'mt'.
-
-Default: `FALSE`}
 }
 \value{
 A ggplot2 geom_hline object for a reference point that can be added

--- a/man/reference_line.Rd
+++ b/man/reference_line.Rd
@@ -4,19 +4,21 @@
 \alias{reference_line}
 \title{Preformatted reference line}
 \usage{
-reference_line(label_name, ref_line, scale_amount = 1)
+reference_line(label_name, ref_line, scale_amount = 1, model_name = "1")
 }
 \arguments{
 \item{label_name}{String. Name of the quantity that users want to
 extract the reference point from}
 
-\item{ref_line}{String of the reference point
-
-Options: Including, but not limited to: "msy", "unfished", "target"}
+\item{ref_line}{String. Reference point(s)}
 
 \item{scale_amount}{Number. A number to scale the y-axis values.
 
 Default: 1}
+
+\item{model_name}{String. Name of the model that will be present in the legend.
+
+Options: Including, but not limited to: "msy", "unfished", "target"}
 }
 \value{
 A ggplot2 geom_hline object for a reference point that can be added


### PR DESCRIPTION
I moved the reference line portion of the plot into it's own function -- `add_reference_line()` -- which gets added to the plot using the (+) operator. 

This feature automatically applies to each input dat. There are 4 conditions that this feature handles 

1. reference lines and values extracted for each input dat. e.g. 
`plot_spawning_biomass(dat=list("mod1"=mod1, "mod2"=mod2), ref_line = "msy")` SBmsy is found for each model.
2. custom values are input by the user for each model in order they are listed in dat. e.g.  `plot_spawning_biomass(dat=list("mod1"=mod1, "mod2"=mod2), ref_line = c("msy"=1000, "msy"=1200))` In this instance, any name or combinations can be used as long as there is one value for each element in the dat list.
3. different reference lines for each model extracted automatically. e.g.  `plot_spawning_biomass(dat=list("mod1"=mod1, "mod2"=mod2), ref_line = c("msy","target"))`
4. Don't include lines at all. Set `ref_line = NULL`