### PR TITLE
fix bug in check for valid URL

### DIFF
--- a/R/convert_output.R
+++ b/R/convert_output.R
@@ -103,7 +103,7 @@ convert_output <- function(
     url_pattern <- "^(https?|ftp|file):\\/\\/[-A-Za-z0-9+&@#\\/%?=~_|!:,.;]*[-A-Za-z0-9+&@#\\/%=~_|]$"
     if (grepl(url_pattern, file)) {
       check <- tryCatch({
-        headers <- utils::curlGetHeaders(file)
+        headers <- curlGetHeaders(file)
         attributes(headers)[["status"]]
       }, error = function(e) {
         404


### PR DESCRIPTION
Long description of a simple fix:

The changes to `convert_output()` in #305 seem to include a copilot error where `curlGetHeaders(file)` is associated with the utils package when it should just be base R. 

After getting an `Invalid URL.` error in a FIMS case study (https://github.com/NOAA-FIMS/case-studies/actions/runs/30038020469/job/89311014050#step:7:26), I tracked down the problem to this line. Because it's wrapped in `tryCatch()`, R can't tell the difference between an invalid URL and a function that doesn't exist, but running outside `tryCatch()` makes it clear which one works:

```
r$> utils::curlGetHeaders("https://raw.githubusercontent.com/r4ss/r4ss/refs/heads/main/inst/extdata/simple_small/Report.sso")
Error: 'curlGetHeaders' is not an exported object from 'namespace:utils'

r$> curlGetHeaders("https://raw.githubusercontent.com/r4ss/r4ss/refs/heads/main/inst/extdata/simple_small/Report.sso")
 [1] "HTTP/2 200 \r\n"                                                                    
 [2] "cache-control: max-age=300\r\n"                                                     
 [3] "content-security-policy: default-src 'none'; style-src 'unsafe-inline'; sandbox\r\n"
...
```

I thought of trying to add an additional testthat test to confirm that `convert_output()` will work with a valid URL, but the URL above as well as https://raw.githubusercontent.com/pfmc-assessments/petrale/main/models/2023.a050.003_FIMS_case-study_wtatage/Report.sso are not being converted correctly right now, so are not well suited to automated testing.