### PR TITLE
chore: add items to Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 ^pkgdown$
 ^\.positai$
 ^\.claude$
+^\.octocov\.yml$
+^\.devcontainer$


### PR DESCRIPTION
Closes #326 

We added `.octocov.yml` and `.devcontainer` into the ` .Rbuildignore` file so they are excluded from the R pacakge builds. 