### PR TITLE
Docs readme update issue 323

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Then, once your converted model results are saved as an object in your R environ
 ```r
 data <- stockplotr::example_data
 
-# create a landings figure from your object
+# create a landings figure and table from your object
 plot_spawning_biomass(data)
-```
+table_landings(data)
+
+ ```
 
 Example Plot | Example Table |
 :------------|---------------:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please refer to the [{asar} tutorial](https://connect.fisheries.noaa.gov/asar_tu
 Then, once your converted model results are saved as an object in your R environment, you can use {stockplotr} functions to create plots from the object.
 
 > [!TIP]
-> {stockplotr} plots or tables are exported as `ggplot2` or `flextable` objects 
+> {stockplotr} plots or tables are exported as `ggplot2` or `gt` objects 
 > meaning that users can use the same process to add new data, formatting, or 
 > other customizations to the plot beyond the baseline made by this package
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,9 @@ stakeholders. We encourage interested users to contribute to this package using
 their custom code when they find it may be useful across the nation.
 
 > [!NOTE]
-> An additional package to plot model diagnostics called [{FIMSdiags}](https://github.com/NOAA-FIMS/FIMSdiags) 
-> is being worked on for the Fisheries Integrated Modelling System [FIMS] that 
-> will natively work with the output used for {stockplotr} since the model output 
-> for FIMS works together with {stockplotr}.
+> Model diagnostic plots within the [{Fisheries Integrated Modelling System (FIMS)}] (https://github.com/NOAA-FIMS/FIMS) are in development.
+> These plots will work natively with {stockplotr} since the FIMS model output virtually matches the {stockplotr} standardized output format.   
+
 
 ## Disclaimer
 


### PR DESCRIPTION
[chore]: Update README
 #323
The README needs to be updated:


Change reference from flextable objects to gt objects in [Tip](https://github.com/nmfs-ost/stockplotr#usage)

Update [example section](https://github.com/nmfs-ost/stockplotr#example) to include example table code:
# create a landings figure from your object
plot_spawning_biomass(data)
table_landings(data)

Change [Note](https://github.com/nmfs-ost/stockplotr#user-community) to read: "Model diagnostic plots within the [Fisheries Integrated Modelling System (FIMS)](https://github.com/NOAA-FIMS/FIMS) are in development. These plots will work natively with {stockplotr} since the FIMS model output virtually matches the {stockplotr} standardized output format."