### PR TITLE
Asar link fix & theme_table add pkg references

### DIFF
--- a/R/html_all_figs_tables.R
+++ b/R/html_all_figs_tables.R
@@ -11,8 +11,8 @@
 #' html and qmd files that show all tables and figures.
 #'
 #' @seealso
-#' \code{\link[asar:create_figures_doc]{asar::create_figures_doc()}},
-#' \code{\link[asar:create_tables_doc]{asar::create_tables_doc()}}
+#' \href{https://github.com/nmfs-ost/asar/blob/main/R/create_figures_doc.R}{asar::create_figures_doc()},
+#' \href{https://github.com/nmfs-ost/asar/blob/main/R/create_tables_doc.R}{asar::create_tables_doc()}
 #'
 #'
 #' @export

--- a/R/theme_table.R
+++ b/R/theme_table.R
@@ -1,11 +1,12 @@
 #' Add NOAA formatting to a table
 #'
-#' @param x Object. Table from gt, flextable, or kableExtra
+#' @param x Object. Table from \pkg{gt}, \pkg{flextable}, or \pkg{kableExtra}
 #'
 #' @returns Add the standard formatting for stock assessment reports for any table.
 #' @details Currently, the function can format table objects from:
-#' flextable ({flextable} package, when installed), gt ({gt}), and
-#' kable ({kableExtra}).
+#' \href{https://ardata-fr.github.io/flextable-book/}{flextable} (\pkg{flextable} package, when installed),
+#' \href{https://cran.r-project.org/web/packages/gt/index.html}{gt} (\pkg{gt}), and
+#' \href{https://cran.r-project.org/web/packages/kableExtra/index.html}{kableExtra} (\pkg{kableExtra}).
 #' @export
 #'
 #' @examples


### PR DESCRIPTION
Fixed asar link to be html in html_all_figs_tables.R file, and added package references for gt, flextable, and kableExtra in the theme_table.R description. 