### PR TITLE
[fix]: substitute pak for devtools for pkg install

### DIFF
--- a/.github/workflows/update-example-data.yml
+++ b/.github/workflows/update-example-data.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::devtools, any::usethis, local::.
+          extra-packages: any::pak, any::usethis, local::.
 
       - name: Update example data
         run: Rscript data-raw/DATASET.R

--- a/data-raw/DATASET.R
+++ b/data-raw/DATASET.R
@@ -2,7 +2,7 @@
 # Path to SS3 output file
 EX_REPORT_PATH <- file.path("inst", "extdata", "Report.sso")
 # Install stockplotr
-devtools::install_local(".")
+pak::local_install(".")
 # Convert output
 example_data <- stockplotr::convert_output(EX_REPORT_PATH)
 # Save object as rda into raw_data


### PR DESCRIPTION
Replacing devtools::install_local in gh action that updates example data
- suggested replacement by the devtools warning